### PR TITLE
feat: public read-only access + Docker Traefik + auth toggle (v1.1.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ AGENTBOARD_HOST=0.0.0.0
 # Auto-generated key is saved to .api_key file (chmod 0600).
 # AGENTBOARD_API_KEY=
 
+# Public read-only mode (GET /api/* without authentication)
+# Set to "false" to require auth for all endpoints.
+AGENTBOARD_PUBLIC_READ=true
+
 # ── Database ────────────────────────────────────────────────
 # Path to SQLite database (relative to WORKDIR or absolute).
 # Default: agentboard.db (in the project root / WORKDIR).
@@ -23,6 +27,12 @@ AGENTBOARD_HOST=0.0.0.0
 # Path to agentboard.toml (relative to WORKDIR or absolute).
 # Default: auto-detect in project root.
 # AGENTBOARD_CONFIG=
+
+# ── Traefik (Docker deployment only) ────────────────────────
+# Uncomment and set these when using Traefik reverse proxy.
+# AGENTBOARD_DOMAIN=board.example.com
+# TRAEFIK_NETWORK=public-net
+# TRAEFIK_CERT_RESOLVER=letsencrypt
 
 # ── Timezone ────────────────────────────────────────────────
 TZ=Asia/Jakarta

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,7 +329,21 @@ CREATE VIRTUAL TABLE pages_fts USING fts5(
 
 ## API Reference
 
-All API endpoints return JSON. Auth via `Authorization: Bearer <api_key>` header.
+All API endpoints return JSON.
+
+### Authentication
+
+| Request Type | Auth Required | Behavior |
+|-------------|--------------|----------|
+| `GET /api/*` | ❌ No (when `public_read=true`) | Browse freely |
+| `POST /api/*` | ✅ Yes | Create resources |
+| `PATCH /api/*` | ✅ Yes | Update resources |
+| `DELETE /api/*` | ✅ Yes | Delete resources |
+| `POST /api/setup` | ❌ No | First-run setup (always public) |
+
+**Public read** is enabled by default. Write operations require: `Authorization: Bearer *** `
+
+To disable public read: `AGENTBOARD_PUBLIC_READ=false` or `[auth] public_read = false` in `agentboard.toml`.
 
 ### Base URL
 `http://localhost:8765/api`
@@ -689,6 +703,7 @@ path = "agentboard.db"         # SQLite file path (relative to project root)
 
 [auth]
 api_key_file = ".api_key"      # File to store/load API key
+public_read = true             # Allow GET /api/* without auth
 
 [features]
 export_enabled = true           # Enable /api/export endpoints

--- a/README.md
+++ b/README.md
@@ -92,13 +92,39 @@ On first run, AgentBoard auto-generates a cryptographically random API key and:
 1. **Prints it to the console** so you can copy it immediately
 2. **Saves it to `.api_key`** in the project root for persistence
 
-All API requests require the key in the `Authorization` header:
+### Public Read-Only Mode
+
+By default (`auth.public_read = true`), all **GET endpoints are accessible without authentication**. This means anyone can browse the board — view projects, tasks, agents, and search.
+
+**Write operations** (POST, PATCH, DELETE) always require the API key:
 
 ```
-Authorization: Bearer ***
+Authorization: Bearer *** 
 ```
 
-You can override it with the `AGENTBOARD_API_KEY` environment variable, or set a custom key file path in `agentboard.toml`.
+To disable public read and require auth for **all** endpoints:
+
+```bash
+# Environment variable
+AGENTBOARD_PUBLIC_READ=false
+
+# Or in agentboard.toml
+[auth]
+public_read = false
+```
+
+You can override the API key with the `AGENTBOARD_API_KEY` environment variable, or set a custom key file path in `agentboard.toml`.
+
+### Auth Summary
+
+| Request Type | Auth Required | Behavior |
+|-------------|--------------|----------|
+| `GET /api/*` | ❌ No (when `public_read=true`) | Browse freely |
+| `POST /api/*` | ✅ Yes | Create resources |
+| `PATCH /api/*` | ✅ Yes | Update resources |
+| `DELETE /api/*` | ✅ Yes | Delete resources |
+| `POST /api/setup` | ❌ No | First-run setup (always public) |
+| Static files + `/` | ❌ No | SPA served always |
 
 ## API Overview
 
@@ -116,22 +142,18 @@ All endpoints return JSON. Base URL: `http://localhost:8765/api`
 | DELETE | `/api/projects/{slug}` | Archive project |
 | POST | `/api/projects/{slug}/restore` | Unarchive project |
 
-### Tasks (6 endpoints)
+### Tasks (8 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/projects/{slug}/tasks` | Tasks in project |
 | GET | `/api/projects/{slug}/tasks?status=review&assignee=cto` | Filter by status/assignee |
 | POST | `/api/projects/{slug}/tasks` | Create task |
+| GET | `/api/tasks/{id}` | Get single task |
 | PATCH | `/api/tasks/{id}` | Update task |
 | DELETE | `/api/tasks/{id}` | Delete task |
-| GET | `/api/tasks/{id}` | Get single task |
-
-### Cross-Project Tasks (1 endpoint)
-
-| Method | Path | Description |
-|--------|------|-------------|
 | GET | `/api/tasks?project=all&assignee=agent-id` | Cross-project task query |
+| GET | `/api/tasks/{id}/children` | List subtasks |
 
 ### Pages (5 endpoints)
 
@@ -190,7 +212,7 @@ All endpoints return JSON. Base URL: `http://localhost:8765/api`
 
 **Note:** `/api/setup` is a one-time endpoint — it can only be called once after the database is created. To add additional projects afterward, use `POST /api/projects`.
 
-**Total: 31 endpoints**
+**Total: 34 endpoints**
 
 ## Agent Integration
 
@@ -290,6 +312,7 @@ path = "agentboard.db"
 
 [auth]
 api_key_file = ".api_key"
+public_read = true
 
 [features]
 export_enabled = true
@@ -318,6 +341,7 @@ Environment variables override `agentboard.toml` values:
 | `AGENTBOARD_API_KEY` | API key (overrides `.api_key` file) | auto-generated |
 | `AGENTBOARD_API_KEY_FILE` | API key file path | `.api_key` |
 | `AGENTBOARD_DB_PATH` | Database file path | `agentboard.db` |
+| `AGENTBOARD_PUBLIC_READ` | Public read-only GET access | `true` |
 
 ### Config is optional
 

--- a/config.py
+++ b/config.py
@@ -39,6 +39,7 @@ DEFAULTS = {
     },
     "auth": {
         "api_key_file": ".api_key",
+        "public_read": True,
     },
     "features": {
         "export_enabled": True,
@@ -159,6 +160,8 @@ def load_config(cli_args: list | None = None) -> dict:
         config["database"]["path"] = os.environ["AGENTBOARD_DB_PATH"]
     if os.environ.get("AGENTBOARD_API_KEY_FILE"):
         config["auth"]["api_key_file"] = os.environ["AGENTBOARD_API_KEY_FILE"]
+    if os.environ.get("AGENTBOARD_PUBLIC_READ"):
+        config["auth"]["public_read"] = os.environ["AGENTBOARD_PUBLIC_READ"].lower() in ("true", "1", "yes")
 
     # 5. CLI argument overrides (highest priority)
     if parsed.port is not None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 # ── AgentBoard Docker Compose ───────────────────────────────
 #
 # Production deployment pattern:
-#   1. Clone repo to /opt/data/agentboard
-#   2. Copy .env.example → .env, set AGENTBOARD_API_KEY
-#   3. docker compose up -d
+#   1. Clone repo: git clone --branch main https://github.com/ajianaz/agentboard.git
+#   2. Copy .env.example → .env, set AGENTBOARD_API_KEY (or auto-generate)
+#   3. Uncomment Traefik labels below and set env vars
+#   4. docker compose up -d
 #
 # All data (DB, API key, config) lives in /opt/data/agentboard
 # via bind mount. Survives container restart/recreate.
@@ -24,12 +25,12 @@ services:
     # Bind mount: host directory → container WORKDIR
     # Host:  /opt/data/agentboard (where this docker-compose.yml lives)
     # Guest: /opt/data/agentboard (Dockerfile WORKDIR)
-    # All runtime data (DB, .api_key, agentboard.toml) persists here.
+    # All runtime data (.db, .api_key, .env) persists here.
     volumes:
       - .:/opt/data/agentboard
 
     ports:
-      - "8765:8765"
+      - "${AGENTBOARD_PORT:-8765}:8765"
 
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/')"]
@@ -38,12 +39,22 @@ services:
       retries: 3
       start_period: 5s
 
-    # ── Traefik reverse proxy (uncomment for public deployment) ──
-    # networks:
-    #   - public-net
+    # ── Traefik reverse proxy ──────────────────────────────────
+    # Uncomment the labels and networks below to enable public access.
+    # Set AGENTBOARD_DOMAIN, TRAEFIK_NETWORK, and TRAEFIK_CERT_RESOLVER
+    # in your .env file (or use the defaults shown).
+    #
     # labels:
     #   - "traefik.enable=true"
-    #   - "traefik.http.routers.agentboard.rule=Host(`board.example.com`)"
+    #   - "traefik.http.routers.agentboard.rule=Host(`${AGENTBOARD_DOMAIN:-board.example.com}`)"
     #   - "traefik.http.routers.agentboard.entrypoints=websecure"
-    #   - "traefik.http.routers.agentboard.tls.certresolver=myresolver"
+    #   - "traefik.http.routers.agentboard.tls.certresolver=${TRAEFIK_CERT_RESOLVER:-letsencrypt}"
     #   - "traefik.http.services.agentboard.loadbalancer.server.port=8765"
+    #
+    # networks:
+    #   - ${TRAEFIK_NETWORK:-public-net}
+
+# Uncomment to connect to an external Traefik network
+# networks:
+#   public-net:
+#     external: true

--- a/onboard.py
+++ b/onboard.py
@@ -51,14 +51,14 @@ DEFAULT_AGENTS = [
         "color": "#f59e0b",
     },
     {
-        "id": "somad",
+        "id": "sosmed",
         "name": "Somad",
         "role": "Social Media Manager — Distribution, Engagement",
         "avatar": "📱",
         "color": "#8b5cf6",
     },
     {
-        "id": "bad-sector",
+        "id": "badsector",
         "name": "Bad Sector",
         "role": "Devil's Advocate — Critical Review, Challenge Ideas",
         "avatar": "😈",

--- a/server.py
+++ b/server.py
@@ -96,8 +96,18 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._serve_file(filepath, self._guess_content_type(path))
             return
 
-        # Auth check for all other routes
-        if path != "/api/setup":
+        # Auth check — public read mode allows GET without token
+        # Public routes: root, /static/*, /api/setup (POST), GET /api/* (when public_read)
+        # Protected routes: POST/PATCH/DELETE /api/* (always need Bearer token)
+        needs_auth = True
+        if path == "/api/setup":
+            needs_auth = False
+        elif method == "GET" and path.startswith("/api/"):
+            cfg = get_config()
+            if cfg.get("auth", {}).get("public_read", True):
+                needs_auth = False
+
+        if needs_auth:
             api_key_hash = hash_key(get_or_create_api_key())
             if not check_auth(self.headers, api_key_hash):
                 self._json_response(

--- a/skills/agentboard/SKILL.md
+++ b/skills/agentboard/SKILL.md
@@ -19,7 +19,8 @@ description: AgentBoard — standalone multi-project task board for agent fleet 
 | **Onboard** | `python3 onboard.py --yes` → registers agents + projects |
 | **API Base** | `http://127.0.0.1:8765/api` |
 | **Dashboard** | `http://127.0.0.1:8765` |
-| **Auth** | `Authorization: Bearer <key from .api_key>` |
+| **Auth** | GET = public (default), POST/PATCH/DELETE = `Bearer *** from .api_key>` |
+| **Public Read** | `auth.public_read=true` default — toggle via env `AGENTBOARD_PUBLIC_READ` |
 | **Tech** | Python 3.11+ stdlib, SQLite WAL, vanilla HTML/CSS/JS |
 
 ## Files
@@ -29,7 +30,7 @@ description: AgentBoard — standalone multi-project task board for agent fleet 
 | `AGENTS.md` | **Single source of truth** — full API reference, schema, conventions |
 | `onboard.py` | Fleet onboard script — registers agents, creates starter projects |
 | `skills/agentboard/SKILL.md` | This file — quick reference hub |
-| `skills/agentboard/references/api_reference.md` | All 31+ endpoints with examples |
+| `skills/agentboard/references/api_reference.md` | All 34+ endpoints with auth table |
 | `skills/agentboard/references/client.py` | **Python client wrapper** — `from client import Board` |
 | `skills/agentboard/references/workflows.md` | Common agent workflows (7 patterns) |
 | `skills/agentboard/references/pitfalls.md` | Gotchas, edge cases, troubleshooting (14 items) |

--- a/skills/agentboard/references/api_reference.md
+++ b/skills/agentboard/references/api_reference.md
@@ -1,8 +1,26 @@
 # AgentBoard API Reference
 
 > Base URL: `http://127.0.0.1:8765/api`
-> Auth: `Authorization: Bearer <key>` (read from `.api_key`)
 > All responses: JSON. Error format: `{"error": "msg", "code": "ERROR_CODE"}`
+
+### Authentication
+
+| Request Type | Auth Required | Behavior |
+|-------------|--------------|----------|
+| `GET /api/*` | ❌ No (when `public_read=true`) | Browse freely |
+| `POST /api/*` | ✅ Yes | Create resources |
+| `PATCH /api/*` | ✅ Yes | Update resources |
+| `DELETE /api/*` | ✅ Yes | Delete resources |
+| `POST /api/setup` | ❌ No | First-run setup (always public) |
+| Static files + `/` | ❌ No | SPA served always |
+
+**Public read** is enabled by default (`auth.public_read = true`). To disable:
+```bash
+AGENTBOARD_PUBLIC_READ=false  # env var
+# or in agentboard.toml: [auth] public_read = false
+```
+
+**Auth header format:** `Authorization: Bearer *** (read from `.api_key`)`
 
 ---
 
@@ -44,6 +62,7 @@
 | GET | `/api/projects/{slug}/tasks?status=review` | Filter by status |
 | GET | `/api/projects/{slug}/tasks?assignee=cto` | Filter by agent |
 | POST | `/api/projects/{slug}/tasks` | Create task |
+| GET | `/api/tasks/{id}` | Get single task |
 | PATCH | `/api/tasks/{id}` | Update task |
 | DELETE | `/api/tasks/{id}` | Delete task |
 | GET | `/api/tasks?project=all` | Cross-project all tasks |

--- a/static/index.html
+++ b/static/index.html
@@ -125,6 +125,9 @@ select{appearance:auto}
 .panel-sec .field-row>div{flex:1}
 .panel-sec select,.panel-sec input,.panel-sec textarea{font-size:13px}
 .panel-comments{border-top:1px solid var(--bd);padding:16px 20px;max-height:300px;overflow-y:auto}
+.panel-desc-readonly{font-size:13px;line-height:1.6;color:var(--t1)}
+.panel-desc-readonly pre{background:var(--bg3);padding:8px;border-radius:var(--rs);overflow-x:auto;margin:8px 0}
+.panel-desc-readonly code{background:var(--bg3);padding:1px 4px;border-radius:3px;font-size:12px}
 .comment{padding:8px 0;border-bottom:1px solid var(--bd)}
 .comment:last-child{border-bottom:none}
 .comment-author{font-weight:500;font-size:12px;color:var(--t1)}
@@ -252,10 +255,13 @@ select{appearance:auto}
   <div class="sb-search"><input id="global-search" placeholder="Search… ⌘K"></div>
   <div class="sb-sec">Projects</div>
   <div id="sb-projects"></div>
-  <a href="#" class="sb-add" id="add-proj-btn">+ New Project</a>
+  ${isAuthenticated()?'<a href="#" class="sb-add" id="add-proj-btn">+ New Project</a>':''}
   <div class="sb-sec">System</div>
   <a href="#agents">🤖 Agents</a>
-  <div class="sb-foot"><span id="sb-ver">v0.1.0</span></div>
+  <div class="sb-foot">
+    <span id="sb-auth" style="cursor:pointer" onclick="showSetup()" title="Click to manage API key">🔓 Read-only</span>
+    <span id="sb-ver">v1.1.0</span>
+  </div>
 </nav>
 
 <main id="app"></main>
@@ -273,15 +279,32 @@ select{appearance:auto}
 // ── State ──
 let S={projects:[],currentSlug:null,poll:null,taskPanelOpen:false};
 
+// ── Auth helpers ──
+function isAuthenticated(){
+  return !!localStorage.getItem('ab_key');
+}
+
 // ── API ──
 async function api(m,p,b){
   const k=localStorage.getItem('ab_key');
-  if(!k){showSetup();return null}
-  const o={method:m,headers:{'Authorization':'Bearer '+k,'Content-Type':'application/json'}};
+  // GET requests work without auth (public read mode)
+  // POST/PATCH/DELETE require auth — prompt setup if no key
+  const isWrite=(m==='POST'||m==='PATCH'||m==='DELETE');
+  if(isWrite&&!k){
+    toast('Authentication required to modify data','err');
+    showSetup();
+    return null;
+  }
+  const o={method:m,headers:{'Content-Type':'application/json'}};
+  if(k)o.headers['Authorization']='Bearer '+k;
   if(b)o.body=JSON.stringify(b);
   try{
     const r=await fetch(p,o);
-    if(r.status===401){localStorage.removeItem('ab_key');showSetup();return null}
+    if(r.status===401){
+      if(k){localStorage.removeItem('ab_key')}
+      if(isWrite){toast('Session expired — please re-enter API key','err');showSetup()}
+      return null;
+    }
     const d=await r.json();
     if(!r.ok){toast(d.error||'Request failed','err');return null}
     return d;
@@ -333,6 +356,41 @@ function openTaskPanel(task){
   S.taskPanelOpen=true;
   const p=document.getElementById('task-panel');
   const priorities={'critical':'#ef4444','high':'#f97316','medium':'#eab308','low':'#22c55e','none':'#6b7280'};
+  const authed=isAuthenticated();
+  let h=`<div class="panel-hdr"><div id="tp-title-text" style="flex:1;font-weight:600;font-size:15px">${esc(task.title)}</div><button class="btn-icon" onclick="closeTaskPanel()">✕</button></div>`;
+  h+=`<div class="panel-body">`;
+  h+=`<div class="panel-sec"><div class="field-row"><div><label>Status</label><div style="padding:6px 0;font-size:13px;color:var(--t1)">${task.status.replace('_',' ')}</div></div>`;
+  h+=`<div><label>Priority</label><div style="padding:6px 0;font-size:13px;color:var(--t1)">${task.priority||'none'}</div></div></div></div>`;
+  h+=`<div class="panel-sec"><div class="field-row"><div><label>Assignee</label><div style="padding:6px 0;font-size:13px;color:var(--t1)">${esc(task.assignee||'Unassigned')}</div></div>`;
+  h+=`<div><label>Due Date</label><div style="padding:6px 0;font-size:13px;color:var(--t1)">${task.due_date||'—'}</div></div></div></div>`;
+  h+=`<div class="panel-sec"><label>Tags</label><div style="padding:6px 0;font-size:13px;color:var(--t1)">${esc((task.tags||[]).join(', ')||'—')}</div></div>`;
+  h+=`<div class="panel-sec"><label>Description</label><div class="panel-desc-readonly">${md(task.description||'No description')}</div></div>`;
+  if(task.status==='proposed'&&authed){
+    h+=`<div style="display:flex;gap:8px"><button class="btn btn-ok" onclick="hitlAction('${task.id}','todo','approved')">✓ Approve</button><button class="btn btn-d" onclick="hitlAction('${task.id}','rejected','rejected')">✕ Reject</button></div>`;
+  }
+  if(task.status==='review'&&authed){
+    h+=`<div style="display:flex;gap:8px"><button class="btn btn-ok" onclick="hitlAction('${task.id}','done','approved')">✓ Approve</button><button class="btn btn-warn" onclick="hitlAction('${task.id}','in_progress','changes requested')">↩ Changes</button></div>`;
+  }
+  if(authed){
+    h+=`<button class="btn btn-s btn-sm" style="margin-top:8px" onclick="editTask('${task.id}')">✏️ Edit</button>`;
+  }
+  h+=`</div>`;
+  h+=`<div class="panel-comments"><div class="comment-add">${authed?'<input id="tp-comment" placeholder="Add comment…"><button class="btn btn-p btn-sm" onclick="addComment(\''+task.id+'\')">Send</button>':'<div style="font-size:12px;color:var(--t2);padding:8px 0">🔓 Authenticate to add comments</div>'}</div><div id="tp-comments"></div></div>`;
+  p.innerHTML=h;
+  document.getElementById('panel-bg').classList.add('open');
+  p.classList.add('open');
+  loadComments(task.id);
+}
+function editTask(id){
+  // Reload task data then show editable panel
+  api('GET','/api/tasks/'+id).then(data=>{
+    if(data)openTaskPanelEdit(data.task||data);
+  });
+}
+function openTaskPanelEdit(task){
+  S.taskPanelOpen=true;
+  const p=document.getElementById('task-panel');
+  const priorities={'critical':'#ef4444','high':'#f97316','medium':'#eab308','low':'#22c55e','none':'#6b7280'};
   const statuses=['proposed','todo','in_progress','review','done','rejected'];
   let h=`<div class="panel-hdr"><input id="tp-title" value="${esc(task.title)}"><button class="btn-icon" onclick="closeTaskPanel()">✕</button></div>`;
   h+=`<div class="panel-body">`;
@@ -342,19 +400,12 @@ function openTaskPanel(task){
   h+=`<div><label>Due Date</label><input id="tp-due" type="date" value="${task.due_date||''}"></div></div></div>`;
   h+=`<div class="panel-sec"><label>Tags</label><input id="tp-tags" value="${esc((task.tags||[]).join(', '))}"></div>`;
   h+=`<div class="panel-sec"><label>Description</label><textarea id="tp-desc" rows="6">${esc(task.description||'')}</textarea></div>`;
-  if(task.status==='proposed'){
-    h+=`<div style="display:flex;gap:8px"><button class="btn btn-ok" onclick="hitlAction('${task.id}','todo','approved')">✓ Approve</button><button class="btn btn-d" onclick="hitlAction('${task.id}','rejected','rejected')">✕ Reject</button></div>`;
-  }
-  if(task.status==='review'){
-    h+=`<div style="display:flex;gap:8px"><button class="btn btn-ok" onclick="hitlAction('${task.id}','done','approved')">✓ Approve</button><button class="btn btn-warn" onclick="hitlAction('${task.id}','in_progress','changes requested')">↩ Changes</button></div>`;
-  }
   h+=`</div>`;
   h+=`<div class="panel-comments"><div class="comment-add"><input id="tp-comment" placeholder="Add comment…"><button class="btn btn-p btn-sm" onclick="addComment('${task.id}')">Send</button></div><div id="tp-comments"></div></div>`;
   p.innerHTML=h;
   document.getElementById('panel-bg').classList.add('open');
   p.classList.add('open');
   loadComments(task.id);
-  // Auto-save on change
   p.querySelectorAll('#tp-title,#tp-status,#tp-priority,#tp-assignee,#tp-due,#tp-tags').forEach(el=>{
     el.addEventListener('change',()=>saveTask(task.id));
   });
@@ -410,11 +461,24 @@ async function doSetup(){
   if(!key){document.getElementById('s-err').textContent='API key required';return}
   localStorage.setItem('ab_key',key);
   toast('Connected!','ok');
+  updateAuthBadge();
   render();
+}
+function updateAuthBadge(){
+  const el=document.getElementById('sb-auth');
+  if(!el)return;
+  if(isAuthenticated()){
+    el.textContent='🔒 Authenticated';
+    el.title='Click to change API key';
+  }else{
+    el.textContent='🔓 Read-only';
+    el.title='Click to enter API key for write access';
+  }
 }
 
 // ── Sidebar ──
 async function loadSidebar(){
+  updateAuthBadge();
   const data=await api('GET','/api/projects');
   if(!data)return;
   S.projects=data.projects||[];
@@ -443,7 +507,6 @@ async function render(){
   closeTaskPanel();
   document.getElementById('sidebar').classList.remove('open');
   document.getElementById('sidebar-overlay').classList.remove('open');
-  if(!localStorage.getItem('ab_key')){showSetup();return}
   switch(view){
     case'overview':await renderOverview(app);break;
     case'board':await renderBoard(app,slug);break;
@@ -497,8 +560,8 @@ async function renderOverview(app){
         <div class="attn-dot" style="background:${color}"></div>
         <div class="attn-info"><div class="title">${esc(t.title)}</div><div class="sub">${esc(t.project_name||'')} · ${label}</div></div>
         <div class="attn-actions">
-          ${t.status==='proposed'?`<button class="btn btn-ok btn-sm" onclick="event.stopPropagation();quickHitl('${t.id}','todo')">✓</button>`:''}
-          ${t.status==='review'?`<button class="btn btn-ok btn-sm" onclick="event.stopPropagation();quickHitl('${t.id}','done')">✓</button>`:''}
+          ${isAuthenticated()&&t.status==='proposed'?`<button class="btn btn-ok btn-sm" onclick="event.stopPropagation();quickHitl('${t.id}','todo')">✓</button>`:''}
+          ${isAuthenticated()&&t.status==='review'?`<button class="btn btn-ok btn-sm" onclick="event.stopPropagation();quickHitl('${t.id}','done')">✓</button>`:''}
         </div>
       </div>`;
     });
@@ -543,7 +606,7 @@ async function renderBoard(app,slug){
     <div class="kb-filters">
       <select id="kb-filter-assignee" onchange="render()"><option value="">All assignees</option></select>
       <select id="kb-filter-priority" onchange="render()"><option value="">All priorities</option>${Object.keys(priorities).map(k=>`<option value="${k}">${k}</option>`).join('')}</select>
-      <button class="btn btn-p btn-sm" onclick="showNewTask('${slug}')">+ New Task</button>
+      ${isAuthenticated()?`<button class="btn btn-p btn-sm" onclick="showNewTask('${slug}')">+ New Task</button>`:''}
     </div>
     <a href="#project/${slug}/docs" class="btn btn-s btn-sm">📄 Docs</a>
     <a href="#project/${slug}/settings" class="btn btn-s btn-sm">⚙️ Settings</a>
@@ -573,7 +636,7 @@ async function renderBoard(app,slug){
 
 // Drag and drop
 let dragId=null;
-function onDragStart(e){dragId=e.target.dataset.id;e.target.classList.add('dragging');e.dataTransfer.effectAllowed='move'}
+function onDragStart(e){if(!isAuthenticated())return;dragId=e.target.dataset.id;e.target.classList.add('dragging');e.dataTransfer.effectAllowed='move'}
 function onDragOver(e){e.preventDefault();e.currentTarget.classList.add('drag-over')}
 function onDragLeave(e){e.currentTarget.classList.remove('drag-over')}
 async function onDrop(e,status,slug){
@@ -635,8 +698,8 @@ async function renderDocs(app,slug){
         <span class="page-icon">📄</span>
         <span class="page-title">${esc(p.title)}</span>
         <span class="page-acts">
-          <button class="btn-icon" style="font-size:12px" onclick="event.stopPropagation();addChildPage('${p.id}','${slug}')">+</button>
-          <button class="btn-icon" style="font-size:12px" onclick="event.stopPropagation();deletePage('${p.id}','${slug}')">🗑</button>
+          ${isAuthenticated()?`<button class="btn-icon" style="font-size:12px" onclick="event.stopPropagation();addChildPage('${p.id}','${slug}')">+</button>
+          <button class="btn-icon" style="font-size:12px" onclick="event.stopPropagation();deletePage('${p.id}','${slug}')">🗑</button>`:''}
         </span>
       </div>`;
       if(hasKids&&expanded)h+=treeHtml(kids,depth+1);
@@ -647,17 +710,17 @@ async function renderDocs(app,slug){
   let h=`<div class="docs-layout">
     <div class="docs-tree">
       <div class="docs-tree-hdr"><h3>${project.icon||'📋'} ${esc(project.name)}</h3>
-        <button class="btn btn-p btn-sm" onclick="addRootPage('${slug}')">+ Page</button>
+        ${isAuthenticated()?`<button class="btn btn-p btn-sm" onclick="addRootPage('${slug}')">+ Page</button>`:''}
       </div>
       ${treeHtmlStr||'<div class="empty" style="padding:24px"><div class="empty-icon">📄</div><h3>No pages</h3></div>'}
     </div>
     <div class="docs-editor" id="docs-editor">
       <div class="docs-editor-hdr">
-        <input id="de-title" placeholder="Page title" onblur="savePage()">
-        <button class="btn btn-s btn-sm" onclick="savePage()">Save</button>
+        <input id="de-title" placeholder="Page title" ${isAuthenticated()?'onblur="savePage()"':'disabled style="opacity:.6"'}>
+        ${isAuthenticated()?'<button class="btn btn-s btn-sm" onclick="savePage()">Save</button>':''}
       </div>
       <div class="docs-editor-body">
-        <div class="docs-md"><textarea id="de-content" placeholder="Write markdown…" oninput="updatePreview()"></textarea></div>
+        <div class="docs-md"><textarea id="de-content" placeholder="Write markdown…" ${isAuthenticated()?'oninput="updatePreview()"':'disabled style="opacity:.6"'}></textarea></div>
         <div class="docs-preview" id="de-preview"></div>
       </div>
     </div>
@@ -761,7 +824,7 @@ async function archiveProject(slug){
 async function renderAgents(app){
   const data=await api('GET','/api/agents');
   const agents=data?.agents||[];
-  let h=`<div style="padding:24px 24px 0;display:flex;justify-content:space-between;align-items:center"><h2 style="font-size:18px;font-weight:600">🤖 Agents</h2><button class="btn btn-p btn-sm" onclick="showNewAgent()">+ Register Agent</button></div>`;
+  let h=`<div style="padding:24px 24px 0;display:flex;justify-content:space-between;align-items:center"><h2 style="font-size:18px;font-weight:600">🤖 Agents</h2>${isAuthenticated()?'<button class="btn btn-p btn-sm" onclick="showNewAgent()">+ Register Agent</button>':''}</div>`;
   h+=`<div class="agents-grid">`;
   if(!agents.length)h+=`<div class="empty" style="grid-column:1/-1"><div class="empty-icon">🤖</div><h3>No agents registered</h3><p>Register an agent to start assigning tasks</p></div>`;
   agents.forEach(a=>{
@@ -809,6 +872,7 @@ async function createAgent(){
 // ── Helpers ──
 function esc(s){if(!s)return'';return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;')}
 function fmtTime(t){if(!t)return'';const d=new Date(t+'Z');const now=new Date();const diff=Math.floor((now-d)/1000);if(diff<60)return'just now';if(diff<3600)return Math.floor(diff/60)+'m ago';if(diff<86400)return Math.floor(diff/3600)+'h ago';return t.slice(0,10)}
+function writeBtn(html){return isAuthenticated()?html:''}
 
 // ── Init ──
 window.addEventListener('hashchange',render);
@@ -822,7 +886,8 @@ document.getElementById('sidebar-overlay').addEventListener('click',()=>{
 });
 document.getElementById('panel-bg').addEventListener('click',closeTaskPanel);
 document.getElementById('modal-bg').addEventListener('click',e=>{if(e.target===e.currentTarget)closeModal()});
-document.getElementById('add-proj-btn').addEventListener('click',e=>{
+const addProjBtn=document.getElementById('add-proj-btn');
+if(addProjBtn)addProjBtn.addEventListener('click',e=>{
   e.preventDefault();
   openModal(`<h3>New Project</h3>
     <div class="form-group"><label>Name</label><input id="np-name" placeholder="Project name"></div>


### PR DESCRIPTION
## Summary

Public read-only auth layer — browse without API key, write requires auth.

## Changes

### Auth Layer (I-001, I-003)
- `GET /api/*` accessible without auth when `public_read=true` (default)
- `POST/PATCH/DELETE` always require `Bearer` token
- Config: `auth.public_read` toggle + `AGENTBOARD_PUBLIC_READ` env var
- `POST /api/setup` always public (first-run only)

### Frontend Read-Only Mode (I-002)
- Sidebar auth badge (🔓 Read-only / 🔑 Authenticated)
- Write buttons hidden when no API key in localStorage
- Task panel shows read-only description
- Docs editor disabled, drag-and-drop blocked
- Users can browse board without login

### Docker Traefik (I-004)
- `docker-compose.yml`: Traefik labels with `${VAR:-default}` pattern
- `.env.example`: full env var documentation
- Configurable: `AGENTBOARD_DOMAIN`, `TRAEFIK_NETWORK`, `TRAEFIK_CERT_RESOLVER`

### Bug Fixes (I-005)
- `onboard.py`: `somad`→`sosmed`, `bad-sector`→`badsector`

### Documentation (I-006, I-007)
- README: auth section, public read table, env vars, 34 endpoints
- AGENTS.md: authentication table, config example
- api_reference.md: auth table, new endpoints
- SKILL.md: auth model reference

## Test Results

| Test | Result |
|------|--------|
| GET /api/projects (no auth) | ✅ 200 |
| GET /api/agents (no auth) | ✅ 200 |
| GET /api/stats (no auth) | ✅ 200 |
| GET /api/activity (no auth) | ✅ 200 |
| GET /api/search (no auth) | ✅ 200 |
| GET /api/export (no auth) | ✅ 200 |
| GET / root (no auth) | ✅ 200 |
| POST /api/projects (no auth) | ✅ 401 blocked |
| PATCH /api/tasks (no auth) | ✅ 401 blocked |
| DELETE /api/tasks (no auth) | ✅ 401 blocked |
| POST /api/projects (with key) | ✅ 201 created |
| GET /api/agents/cto (no auth) | ✅ 200 |
| POST /api/setup (no auth) | ✅ 400 (already done) |

## Files Changed (10 files, +212 -54)

- `config.py` — public_read config + env var
- `server.py` — auth logic rewrite
- `static/index.html` — read-only mode UI
- `docker-compose.yml` — Traefik env vars
- `.env.example` — env var docs
- `onboard.py` — agent ID fixes
- `README.md` — auth docs
- `AGENTS.md` — auth table
- `skills/agentboard/SKILL.md` — quick ref
- `skills/agentboard/references/api_reference.md` — API auth table

## Milestone

Closes issues: I-001, I-002, I-003, I-004, I-005, I-006, I-007
Milestone: v1.1.0 (#9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled public read access to API GET endpoints by default (configurable via `AGENTBOARD_PUBLIC_READ`)
  * Added authentication badge to sidebar footer displaying current auth state
  * Implemented read-only UI mode for unauthenticated users

* **Documentation**
  * Updated API documentation with new per-request authentication rules
  * Clarified that GET endpoints are public by default while POST/PATCH/DELETE require authentication

* **Chores**
  * Updated agent identifiers for consistency
  * Enhanced Docker deployment configuration with Traefik support and configurable port mapping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->