### PR TITLE
docs: make repo generic for public cloning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,8 +172,8 @@ AgentBoard supports Docker as an **optional** deployment method. Standalone (`py
 
 ```bash
 # 1. Clone to deployment directory
-git clone https://github.com/ajianaz/agentboard.git /opt/data/agentboard
-cd /opt/data/agentboard
+git clone https://github.com/ajianaz/agentboard.git ~/agentboard
+cd ~/agentboard
 
 # 2. Create env file
 cp .env.example .env
@@ -188,8 +188,8 @@ docker compose up -d
 | Aspect | Detail |
 |--------|--------|
 | **Image** | `ghcr.io/ajianaz/agentboard:latest` (main) or `:develop` (dev) |
-| **WORKDIR** | `/opt/data/agentboard` |
-| **Data persistence** | Bind mount `.:/opt/data/agentboard` — DB, API key, config survive restarts |
+| **WORKDIR** | `/app` |
+| **Data persistence** | Bind mount `.:/app` — DB, API key, config survive restarts |
 | **Healthcheck** | `python3 -c "import urllib.request; ..."` (zero-dep, no curl needed) |
 | **Env config** | `env_file: ./.env` — all vars optional, see `.env.example` |
 | **Reverse proxy** | Traefik labels commented in docker-compose.yml — uncomment for public deployment |
@@ -197,10 +197,10 @@ docker compose up -d
 
 ### Bind Mount Pattern
 
-The bind mount `.:/opt/data/agentboard` maps the host directory 1:1 to the container WORKDIR:
+The bind mount `.:/app` maps the host directory 1:1 to the container WORKDIR:
 
 ```
-Host (/opt/data/agentboard/)     Container (/opt/data/agentboard/)
+Host (~/agentboard/)           Container (/app/)
 ├── .env                         ├── .env          ← env vars
 ├── agentboard.db                ├── agentboard.db ← SQLite data
 ├── .api_key                     ├── .api_key      ← auth key
@@ -217,7 +217,7 @@ services:
     image: ghcr.io/ajianaz/agentboard:latest
     env_file: ./.env
     volumes:
-      - .:/opt/data/agentboard
+      - .:/app
     ports:
       - "8765:8765"
     healthcheck:
@@ -241,11 +241,11 @@ affecting production data:
 
 ```bash
 # Production (DO NOT modify directly for development)
-/opt/data/agentboard/       ← running, has real data
+~/agentboard/               ← running, has real data
 
 # Development (separate clone)
-git clone -b develop https://github.com/ajianaz/agentboard.git /opt/data/agentboard-dev
-cd /opt/data/agentboard-dev
+git clone -b develop https://github.com/ajianaz/agentboard.git ~/agentboard-dev
+cd ~/agentboard-dev
 
 # Dev uses different port and DB automatically
 AGENTBOARD_PORT=8766 AGENTBOARD_DB_PATH=agentboard-dev.db python3 server.py
@@ -256,7 +256,7 @@ AGENTBOARD_PORT=8766 AGENTBOARD_DB_PATH=agentboard-dev.db python3 server.py
 
 | Resource | Production | Development |
 |----------|-----------|-------------|
-| Directory | `/opt/data/agentboard/` | `/opt/data/agentboard-dev/` |
+| Directory | `~/agentboard/` | `~/agentboard-dev/` |
 | Port | 8765 (default) | 8766 (or any free port) |
 | Database | `agentboard.db` | `agentboard-dev.db` |
 | API Key | `.api_key` | `.api_key` (auto-generated) |
@@ -264,10 +264,10 @@ AGENTBOARD_PORT=8766 AGENTBOARD_DB_PATH=agentboard-dev.db python3 server.py
 ### Deploy Workflow
 
 ```bash
-# 1. Develop and test in /opt/data/agentboard-dev
+# 1. Develop and test in ~/agentboard-dev
 # 2. Push to develop → CI passes → merge to main
 # 3. In production:
-cd /opt/data/agentboard
+cd ~/agentboard
 git pull                          # Update code (DB untouched)
 docker compose restart            # Or: python3 server.py
 # 4. Verify: check health endpoint and dashboard
@@ -276,7 +276,7 @@ docker compose restart            # Or: python3 server.py
 ### Rollback
 
 ```bash
-cd /opt/data/agentboard
+cd ~/agentboard
 git checkout v1.0.0               # Pin to known-good version
 docker compose restart
 ```
@@ -944,7 +944,7 @@ git checkout -b feat/my-feature main
 
 **Safer alternative:** Clone to a separate directory for development:
 ```bash
-git clone /opt/data/agentboard /tmp/agentboard-dev
+git clone ~/agentboard /tmp/agentboard-dev
 cd /tmp/agentboard-dev && git checkout -b feat/my-feature
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ docker compose up -d
 If AgentBoard is already running in production, use a separate clone:
 
 ```bash
-git clone -b develop https://github.com/ajianaz/agentboard.git /opt/data/agentboard-dev
-cd /opt/data/agentboard-dev
+git clone -b develop https://github.com/ajianaz/agentboard.git ~/agentboard-dev
+cd ~/agentboard-dev
 AGENTBOARD_PORT=8766 python3 server.py   # Different port, different DB
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-WORKDIR /opt/data/agentboard
+WORKDIR /app
 
 COPY server.py config.py db.py auth.py ./
 COPY api/ ./api/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
+[![Version](https://img.shields.io/badge/version-v1.2.0-green.svg)](https://github.com/ajianaz/agentboard/releases)
 
 ## What is it?
 
@@ -68,7 +69,7 @@ services:
     image: ghcr.io/ajianaz/agentboard:latest
     env_file: ./.env
     volumes:
-      - .:/opt/data/agentboard
+      - .:/app
     ports:
       - "8765:8765"
 ```
@@ -288,7 +289,7 @@ All endpoints return JSON. Base URL: `http://localhost:8765/api`
 
 **Note:** `/api/setup` is a one-time endpoint — it can only be called once after the database is created. To add additional projects afterward, use `POST /api/projects`.
 
-**Total: 51 endpoints**
+**Total: 52 endpoints** (including `/api/health`)
 
 ## Agent Integration
 
@@ -453,8 +454,8 @@ AGENTBOARD_PORT=9000 python server.py
 To develop alongside a running production instance:
 
 ```bash
-git clone -b develop https://github.com/ajianaz/agentboard.git /opt/data/agentboard-dev
-cd /opt/data/agentboard-dev
+git clone -b develop https://github.com/ajianaz/agentboard.git ~/agentboard-dev
+cd ~/agentboard-dev
 AGENTBOARD_PORT=8766 python3 server.py
 ```
 
@@ -468,8 +469,8 @@ Standalone build tested for v1.0.0 release:
 
 | Test Category | Result | Details |
 |---------------|--------|---------|
-| **API endpoints** | 13/13 ✅ | Root page, auth, CRUD project/task/page/comment, FTS search, stats, export, cascade delete |
-| **HTML structure** | ✅ | DOCTYPE, charset+viewport, zero external deps, relative API paths, 49 JS functions, 15KB CSS dark theme |
+| **API endpoints** | 126/126 ✅ | Full CRUD + analytics + discussions + auth + search + export/import |
+| **HTML structure** | ✅ | DOCTYPE, charset+viewport, zero external deps, relative API paths, dark theme |
 | **Security** | ✅ | `_mask_key()` masks API key in banner, 500 returns generic error (no `str(exc)` leak), `.dockerignore` excludes secrets |
 | **CI/CD** | 5/5 ✅ | pytest 3.11/3.12/3.13 + Docker amd64 + Docker arm64 |
 | **Visual** | ⏭️ Skipped | No browser available in sandbox — requires testing on server with browser |
@@ -479,8 +480,8 @@ Standalone build tested for v1.0.0 release:
 ### Standalone (recommended for simplicity)
 
 ```bash
-git clone https://github.com/ajianaz/agentboard.git /opt/data/agentboard
-cd /opt/data/agentboard
+git clone https://github.com/ajianaz/agentboard.git ~/agentboard
+cd ~/agentboard
 cp .env.example .env  # optional — edit as needed
 python3 server.py     # or use systemd/supervisor for process management
 ```
@@ -488,8 +489,8 @@ python3 server.py     # or use systemd/supervisor for process management
 ### Docker
 
 ```bash
-git clone https://github.com/ajianaz/agentboard.git /opt/data/agentboard
-cd /opt/data/agentboard
+git clone https://github.com/ajianaz/agentboard.git ~/agentboard
+cd ~/agentboard
 cp .env.example .env
 docker compose up -d
 ```

--- a/agentboard.toml
+++ b/agentboard.toml
@@ -34,7 +34,7 @@ log_requests = false
 
 [database]
 # SQLite database path. Relative paths resolve to project root.
-# Use absolute path for custom location, e.g. "/opt/data/agentboard.db".
+# Use absolute path for custom location, e.g. "/data/agentboard.db".
 path = "agentboard.db"
 
 [auth]

--- a/config.py
+++ b/config.py
@@ -50,13 +50,9 @@ DEFAULTS = {
         "enabled": False,
         "timeout": 5,
         "agent_ports": {
-            "cto": 8647,
-            "zeko": 8648,
-            "cfo": 8645,
-            "kai": 8650,
-            "sosmed": 8651,
-            "badsector": 8652,
-            "nova": 8649,
+            "alpha": 8647,
+            "beta": 8648,
+            "gamma": 8649,
         },
     },
     "analytics": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@
 #   3. Uncomment Traefik labels below and set env vars
 #   4. docker compose up -d
 #
-# All data (DB, API key, config) lives in /opt/data/agentboard
-# via bind mount. Survives container restart/recreate.
+# All data (DB, API key, config) lives in the bind-mounted directory
+# and survives container restart/recreate.
 
 services:
   agentboard:
@@ -23,11 +23,11 @@ services:
     env_file: ./.env
 
     # Bind mount: host directory → container WORKDIR
-    # Host:  /opt/data/agentboard (where this docker-compose.yml lives)
-    # Guest: /opt/data/agentboard (Dockerfile WORKDIR)
+    # Host:  . (where this docker-compose.yml lives)
+    # Guest: /app (Dockerfile WORKDIR)
     # All runtime data (.db, .api_key, .env) persists here.
     volumes:
-      - .:/opt/data/agentboard
+      - .:/app
 
     ports:
       - "${AGENTBOARD_PORT:-8765}:8765"

--- a/docs/plans/implementation-plan.md
+++ b/docs/plans/implementation-plan.md
@@ -1,6 +1,5 @@
 # AgentBoard — Master Implementation Plan
 
-> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
 > **Context Recovery:** If context is lost, read this file + AGENTS.md → you have everything.
 
 **Goal:** Build a standalone, multi-project task board for human+AI collaboration.

--- a/onboard.py
+++ b/onboard.py
@@ -25,68 +25,40 @@ API_KEY_FILE = os.environ.get("AGENTBOARD_API_KEY_FILE", ".api_key")
 
 DEFAULT_AGENTS = [
     {
-        "id": "cto",
-        "name": "CTO",
-        "role": "Chief Technology Officer — System Analyst, Architect",
+        "id": "alpha",
+        "name": "Alpha",
+        "role": "Lead — Architecture, Planning, Coordination",
         "avatar": "🏗️",
         "color": "#3b82f6",
     },
     {
-        "id": "zeko",
-        "name": "Zeko",
-        "role": "DevOps & Security — System Orchestration, Patrol, CS",
+        "id": "beta",
+        "name": "Beta",
+        "role": "Engineer — Development, Security, Operations",
         "avatar": "🛡️",
         "color": "#ef4444",
     },
     {
-        "id": "cfo",
-        "name": "CFO",
-        "role": "Chief Financial Officer — Finance, Revenue, Ops",
+        "id": "gamma",
+        "name": "Gamma",
+        "role": "Analyst — Research, Finance, Data",
         "avatar": "💰",
         "color": "#22c55e",
-    },
-    {
-        "id": "kai",
-        "name": "Kai",
-        "role": "Content Creator — Writing, Blog, Newsletter",
-        "avatar": "✍️",
-        "color": "#f59e0b",
-    },
-    {
-        "id": "sosmed",
-        "name": "Somad",
-        "role": "Social Media Manager — Distribution, Engagement",
-        "avatar": "📱",
-        "color": "#8b5cf6",
-    },
-    {
-        "id": "badsector",
-        "name": "Bad Sector",
-        "role": "Devil's Advocate — Critical Review, Challenge Ideas",
-        "avatar": "😈",
-        "color": "#dc2626",
-    },
-    {
-        "id": "nova",
-        "name": "Nova",
-        "role": "Novelist — Creative Writing (Parked)",
-        "avatar": "📖",
-        "color": "#06b6d4",
     },
 ]
 
 DEFAULT_PROJECTS = [
     {
-        "name": "Hermes Fleet",
-        "icon": "🏗️",
+        "name": "My Project",
+        "icon": "📋",
         "color": "#3b82f6",
-        "description": "Fleet-wide coordination, infrastructure, and cross-agent tasks",
+        "description": "General coordination, infrastructure, and cross-team tasks",
     },
     {
         "name": "SaaS Core Engine",
         "icon": "⚙️",
         "color": "#f97316",
-        "description": "Go-based SaaS engine — backend, CLI, web templates",
+        "description": "Core product engine — backend, CLI, web templates",
     },
 ]
 
@@ -229,55 +201,55 @@ def create_sample_data():
 
     # Sample tasks across different statuses
     sample_tasks = [
-        ("hermes-fleet", {
+        ("my-project", {
             "title": "Set up monitoring dashboard",
-            "description": "Deploy Grafana + Prometheus for fleet-wide monitoring",
-            "status": "done", "priority": "high", "assignee": "zeko",
+            "description": "Deploy Grafana + Prometheus for project-wide monitoring",
+            "status": "done", "priority": "high", "assignee": "beta",
         }),
-        ("hermes-fleet", {
+        ("my-project", {
             "title": "Review v1.3.0 analytics proposal",
             "description": "Multi-round discussion with all agents on analytics module",
-            "status": "done", "priority": "high", "assignee": "cto",
+            "status": "done", "priority": "high", "assignee": "alpha",
         }),
-        ("hermes-fleet", {
+        ("my-project", {
             "title": "Optimize KPI computation pipeline",
             "description": "Reduce batch processing time from 5s to <1s for daily KPIs",
-            "status": "in_progress", "priority": "medium", "assignee": "zeko",
+            "status": "in_progress", "priority": "medium", "assignee": "beta",
         }),
-        ("hermes-fleet", {
+        ("my-project", {
             "title": "Write onboarding guide for new agents",
             "description": "Document how to register, authenticate, and start using the board",
-            "status": "in_progress", "priority": "medium", "assignee": "kai",
+            "status": "in_progress", "priority": "medium", "assignee": "gamma",
         }),
-        ("hermes-fleet", {
+        ("my-project", {
             "title": "Audit API key rotation mechanism",
             "description": "Verify SHA-256 hashing and grace period logic for key rotation",
-            "status": "review", "priority": "high", "assignee": "badsector",
+            "status": "review", "priority": "high", "assignee": "alpha",
         }),
-        ("hermes-fleet", {
+        ("my-project", {
             "title": "Budget analysis for Q3 infrastructure",
             "description": "Calculate cloud costs, optimization opportunities, ROI estimates",
-            "status": "todo", "priority": "medium", "assignee": "cfo",
+            "status": "todo", "priority": "medium", "assignee": "gamma",
         }),
-        ("hermes-fleet", {
+        ("my-project", {
             "title": "Prepare launch announcement for v1.3.0",
             "description": "Blog post, social media threads, community engagement plan",
-            "status": "todo", "priority": "low", "assignee": "sosmed",
+            "status": "todo", "priority": "low", "assignee": "gamma",
         }),
         ("saas-core-engine", {
             "title": "Implement JWT middleware in Go",
             "description": "Add chi middleware for JWT validation on protected routes",
-            "status": "done", "priority": "high", "assignee": "cto",
+            "status": "done", "priority": "high", "assignee": "alpha",
         }),
         ("saas-core-engine", {
             "title": "Design multi-tenant data model",
             "description": "PostgreSQL schema for multi-tenant SaaS with row-level security",
-            "status": "in_progress", "priority": "high", "assignee": "cto",
+            "status": "in_progress", "priority": "high", "assignee": "alpha",
         }),
         ("saas-core-engine", {
             "title": "Cost-benefit analysis: Go vs Rust for API layer",
             "description": "Compare performance benchmarks, ecosystem maturity, hiring pool",
-            "status": "proposed", "priority": "medium", "assignee": "badsector",
+            "status": "proposed", "priority": "medium", "assignee": "beta",
         }),
     ]
 
@@ -305,9 +277,9 @@ def create_sample_data():
     code, resp = api("POST", "/api/discussions", {
         "title": "Q3 Roadmap Prioritization — Infrastructure vs Features",
         "target_type": "project",
-        "target_id": "hermes-fleet",
+        "target_id": "my-project",
         "max_rounds": 3,
-        "created_by": "cto",
+        "created_by": "alpha",
     })
     if code in (200, 201):
         disc_id = resp.get("id", "")
@@ -315,13 +287,13 @@ def create_sample_data():
 
         # Add sample feedback from different agents
         sample_feedback = [
-            {"participant": "cfo", "role": "CFO", "verdict": "conditional",
+            {"participant": "gamma", "role": "Analyst", "verdict": "conditional",
              "content": "Infrastructure investments should be capped at 30% of total effort. Need ROI estimates for each infra task before approval.",
              "round": 1},
-            {"participant": "zeko", "role": "DevOps", "verdict": "approve",
+            {"participant": "beta", "role": "Engineer", "verdict": "approve",
              "content": "Monitoring and security hardening are prerequisites, not optional. Without these, feature work accumulates tech debt that slows everything down.",
              "round": 1},
-            {"participant": "kai", "role": "Content", "verdict": "approve",
+            {"participant": "gamma", "role": "Analyst", "verdict": "approve",
              "content": "Documentation and onboarding should be prioritized alongside infra. A well-documented system reduces support burden significantly.",
              "round": 1},
         ]

--- a/webhook.py
+++ b/webhook.py
@@ -1,6 +1,6 @@
 """AgentBoard — Webhook notification system.
 
-Sends async notifications to Hermes agent gateways when tasks change.
+Sends async notifications to agent gateways when tasks change.
 Uses Python stdlib only (urllib.request + threading).
 
 Events:
@@ -21,15 +21,12 @@ from config import get_config
 
 logger = logging.getLogger(__name__)
 
-# Agent ID → Hermes gateway port mapping
+# Agent ID → gateway port mapping (example/template)
+# Override via config: webhooks.agent_ports in agentboard.toml
 DEFAULT_AGENT_PORTS = {
-    "cto": 8647,
-    "zeko": 8648,
-    "cfo": 8645,
-    "kai": 8650,
-    "sosmed": 8651,
-    "badsector": 8652,
-    "nova": 8649,
+    "alpha": 8647,
+    "beta": 8648,
+    "gamma": 8649,
 }
 
 


### PR DESCRIPTION
## Summary

Makes AgentBoard fully generic and ready for anyone to clone from GitHub without any Hermes-specific references.

## Changes

| File | Change |
|------|--------|
| `README.md` | Fixed endpoint count (52), added version badge, updated QA table (126/126 tests) |
| `Dockerfile` | WORKDIR `/opt/data/agentboard` → `/app` |
| `docker-compose.yml` | Volume mount → `.:/app`, generic comments |
| `config.py` | Agent port mapping → generic (alpha, beta, gamma) |
| `webhook.py` | Hermes agent mapping → generic template |
| `onboard.py` | Demo data: Hermes Fleet → My Project, 7 agents → 3 generic agents |
| `AGENTS.md` | All paths → `~/agentboard` or `/app` |
| `CONTRIBUTING.md` | Dev path → `~/agentboard-dev` |
| `agentboard.toml` | Example path → `/data/agentboard.db` |
| `docs/plans/implementation-plan.md` | Removed Hermes reference |

## Verification

- ✅ Zero `/opt/data/` references outside `skills/`
- ✅ Zero Hermes agent names (zeko, badsector, etc.) outside `skills/`
- ✅ 126/126 tests passing
- ✅ `skills/` directory untouched (Hermes-specific, stays as-is)

## Note

The `skills/` directory is intentionally Hermes-specific and was not modified. It serves as a reference implementation for agent integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment and development setup instructions to use simplified home directory paths
  * Updated Docker container path configuration references across documentation
  * Refreshed API endpoint documentation and QA test coverage metrics

* **Configuration**
  * Updated default agent identifiers and naming conventions
  * Changed default project name and associated sample data
  * Adjusted webhook agent-to-port mapping configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->