### PR TITLE
docs: update to v1.5.0 — CHANGELOG, README, badge, endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,40 @@ All notable changes to AgentBoard are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [1.3.0] - Unreleased
+## [1.5.0] - 2026-04-27
+
+### Added
+- **Visibility Model v2** — Per-page visibility control (public/private) in docs hub
+- **Standalone Webhook** — Direct delivery to AgentBoard without http_router relay, with HMAC-SHA256 signing
+- **Webhook Task Update** — `/api/webhook/task` endpoint for external activity logging
+- **Public Stats API** — `/api/stats/public` for anonymized board statistics
+- **Split Pending View** — Overview dashboard separates Todo and In Review counts
+- **Discussion Webhook Ports** — Configurable ports per discussion for multi-agent coordination
+- **Discussion Zombie Mitigation** — Auto-detection and cleanup of stalled discussions
+
+### Changed
+- **UI Refactor** — Merged Home + Dashboard into single Overview page
+- **Sidebar** — Analytics and Agents sections hidden from default sidebar
+- **PR #105 fixes** — Stale projSlug reference, hidden projects no longer leak in public stats
+
+### Fixed
+- Pages API visibility filter used wrong table alias (pg → p/c)
+- Migration v7 idempotent — skips duplicate column errors gracefully
+- Migration v7 — drops FTS before pages rebuild, adds error logging
+- Stats totals inconsistent — filter non-archived, add todo_tasks count
+
+## [1.4.0] - 2026-04-26
+
+### Added
+- **Standalone Tools** — `tools/client.py` for HTTP API client and `tools/discussion.py` for discussion management
+- **Agent Sync** — Hermes agent fleet integration via direct webhooks
+- **Public Readiness** — Repo cleaned for public cloning (no secrets, generic docs)
+
+### Changed
+- **Documentation** — Made repo generic (removed Hermes-specific references from public docs)
+- **Gitignore** — Added *.db, *.db-shm, *.db-wal, .api_key, .env to prevent secret leaks
+
+## [1.3.0] - 2026-04-25
 
 ### Added
 - **Analytics Engine** — KPI computation with configurable intervals (5min default), auto-cleanup of stale data

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
-[![Version](https://img.shields.io/badge/version-v1.2.0-green.svg)](https://github.com/ajianaz/agentboard/releases)
+[![Version](https://img.shields.io/badge/version-v1.5.0-green.svg)](https://github.com/ajianaz/agentboard/releases)
 
 ## What is it?
 
@@ -289,7 +289,19 @@ All endpoints return JSON. Base URL: `http://localhost:8765/api`
 
 **Note:** `/api/setup` is a one-time endpoint — it can only be called once after the database is created. To add additional projects afterward, use `POST /api/projects`.
 
-**Total: 52 endpoints** (including `/api/health`)
+### Webhook (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/webhook/task` | Receive external task updates (HMAC-signed) |
+
+### Public Stats (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/stats/public` | Anonymized board statistics |
+
+**Total: 54 endpoints** (including `/api/health`)
 
 ## Agent Integration
 
@@ -355,6 +367,7 @@ Each project can have its own status workflow:
 ┌─────────────────────────────────────┐
 │  server.py (Python stdlib)          │
 │  Routing + Auth + API handlers      │
+│  + HMAC webhook receiver            │
 └──────────────┬──────────────────────┘
                │ SQLite
                ▼
@@ -363,6 +376,7 @@ Each project can have its own status workflow:
 │  projects, tasks, pages, agents     │
 │  activity, kpi_daily, kpi_weekly    │
 │  discussions, discussion_feedback    │
+│  webhook_events                     │
 └─────────────────────────────────────┘
 ```
 

--- a/server.py
+++ b/server.py
@@ -19,7 +19,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
 from pathlib import Path
 
-VERSION = "1.4.1"
+VERSION = "1.5.0"
 
 # Local imports
 from config import get_config


### PR DESCRIPTION
## Changes

- **server.py**: VERSION 1.4.1 → 1.5.0
- **CHANGELOG.md**: Add v1.4.0 and v1.5.0 release entries
- **README.md**: Update version badge, add Webhook + Public Stats endpoints, update architecture diagram, fix endpoint count (52→54)

## Files
- `server.py` — version bump
- `CHANGELOG.md` — 2 new release sections
- `README.md` — 4 documentation updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version 1.5.0 released with webhook delivery with cryptographic signing, public statistics endpoint, enhanced dashboard navigation, and automated stalled-discussion detection.
  * Version 1.4.0 released with HTTP client tools and agent fleet integration.

* **Documentation**
  * Updated API documentation with newly available endpoints and expanded endpoint count.
  * Updated version references across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->