### PR TITLE
fix: add missing p.visibility to /api/pages query — resolves 500 error

### DIFF
--- a/api/pages.py
+++ b/api/pages.py
@@ -75,7 +75,7 @@ def list_all_pages(params, query, body, headers):
 
     # Get all NON-ARCHIVED projects with their page counts
     projects = conn.execute(
-        f"""SELECT p.id, p.slug, p.name, p.icon, p.color,
+        f"""SELECT p.id, p.slug, p.name, p.icon, p.color, p.visibility,
                   (SELECT COUNT(*) FROM pages c WHERE c.project_id = p.id AND c.parent_id IS NULL {page_vis_c}) as root_page_count
            FROM projects p
            WHERE p.is_archived = 0 {proj_vis}

--- a/server.py
+++ b/server.py
@@ -19,7 +19,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
 from pathlib import Path
 
-VERSION = "1.5.0"
+VERSION = "1.5.1"
 
 # Local imports
 from config import get_config


### PR DESCRIPTION
## Bug

`GET /api/pages` returns **500 Internal Server Error** on both PROD and DEV.

## Root Cause

`list_all_pages()` in `api/pages.py` line 78 SELECTs `p.id, p.slug, p.name, p.icon, p.color` but **not** `p.visibility`. However, line 104 references `proj["visibility"]` when building the response dict.

This causes `KeyError: 'visibility'` → unhandled exception → 500.

## Fix

- Added `p.visibility` to the SELECT projection (1 line change)
- Bumped version: 1.5.0 → 1.5.1

## Impact

- Affects: `company.ajianaz.dev` (PROD) and `board.ajianaz.dev` (DEV)
- Both `/api/pages` and docs hub (`#docs`) were completely broken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project visibility is now correctly returned in API responses from the pages list endpoint.

* **Chores**
  * Version updated to 1.5.1, affecting the health check endpoint and HTML file ETags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->