### PR TITLE
fix: address CodeRabbit PR #125 review — remove Hermes-specific defaults

### DIFF
--- a/agentboard.toml.example
+++ b/agentboard.toml.example
@@ -52,5 +52,6 @@ retention_activity = 180
 
 [webhooks]
 enabled = false
-timeout = 10
+timeout = 5
+# agent_ports = { my_agent = 9001 }  # set explicitly when enabling webhooks
 # secret = "change-me-to-a-random-string"

--- a/config.py
+++ b/config.py
@@ -59,15 +59,7 @@ DEFAULTS = {
     "webhooks": {
         "enabled": False,
         "timeout": 5,
-        "agent_ports": {
-                "zeko": 8648,
-                "cfo": 8645,
-                "cto": 8647,
-                "badsector": 8652,
-                "kai": 8650,
-                "sosmed": 8651,
-                "novelist": 8649,
-            },
+        "agent_ports": {},
     },
     "analytics": {
         "interval_seconds": 300,

--- a/webhook.py
+++ b/webhook.py
@@ -27,17 +27,10 @@ from config import get_config
 
 logger = logging.getLogger(__name__)
 
-# Agent ID → gateway port mapping (Hermes fleet)
+# Agent ID → gateway port mapping
 # Override via config: webhooks.agent_ports in agentboard.toml
-DEFAULT_AGENT_PORTS = {
-    "zeko": 8648,
-    "cfo": 8645,
-    "cto": 8647,
-    "badsector": 8652,
-    "kai": 8650,
-    "sosmed": 8651,
-    "novelist": 8649,
-}
+# No defaults — users must configure their own agent ports when enabling webhooks.
+DEFAULT_AGENT_PORTS = {}
 
 
 def _get_agent_ports() -> dict:
@@ -64,7 +57,7 @@ def _get_webhook_secret() -> str:
     if secret:
         return secret
     # 3. .env file (host/dev mode)
-    env_path = "/opt/data/.env"
+    env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
     if os.path.exists(env_path):
         try:
             with open(env_path) as f:


### PR DESCRIPTION
## Summary
- `config.py`: `webhooks.agent_ports` default → `{}` (was hardcoded Hermes ports)
- `webhook.py`: `DEFAULT_AGENT_PORTS` → `{}` (remove Hermes fleet mapping)
- `webhook.py`: `.env` path → relative to script (was hardcoded `/opt/data/.env`)
- `agentboard.toml.example`: timeout `10` → `5` (align with config.py default)
- `agentboard.toml.example`: add commented `agent_ports` example

## Addresses
- CodeRabbit PR #125 🟠 Major: Hermes webhook defaults in config.py
- CodeRabbit PR #125 🟡 Minor: timeout inconsistency

## Test
- 131 tests passing