### PR TITLE
feat: key-scoped rate limiting + permission-based endpoint access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build/
 agentboard.db.empty-backup
 agentboard.db.bak
 agentboard.toml
+graphify-out/

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -97,6 +97,53 @@ def is_authenticated(headers: dict) -> bool:
     """
     return headers.get("x-auth-valid", "false") == "true"
 
+
+def get_permissions(headers: dict) -> list[str]:
+    """Get the list of permissions from the X-Key-Permissions header.
+
+    Returns a list like ["read", "write"] or ["read", "write", "admin"].
+    """
+    raw = headers.get("x-key-permissions", "")
+    return [p.strip() for p in raw.split(",") if p.strip()]
+
+
+def has_permission(headers: dict, required: str) -> bool:
+    """Check if the current request has a specific permission.
+
+    Permission hierarchy: admin includes all permissions.
+    """
+    perms = get_permissions(headers)
+    if "admin" in perms:
+        return True
+    return required in perms
+
+
+def require_permission(*permissions: str):
+    """Decorator to enforce permission on an API handler.
+
+    Usage:
+        @router.post("/api/projects")
+        @require_permission("admin")
+        def create_project(params, query, body, headers):
+            ...
+    """
+    def decorator(fn):
+        def wrapper(params, query, body, headers):
+            # Skip permission check for unauthenticated (public) requests
+            # — they already can't reach write endpoints via server.py auth
+            if not is_authenticated(headers):
+                return fn(params, query, body, headers)
+
+            for perm in permissions:
+                if not has_permission(headers, perm):
+                    return 403, {
+                        "error": f"Permission denied: requires '{perm}'",
+                        "code": "FORBIDDEN",
+                    }
+            return fn(params, query, body, headers)
+        return wrapper
+    return decorator
+
 # Route modules will be imported here when they exist
 # Each module calls router.get/post/patch/delete to register its routes.
 # from api import projects, tasks, pages, agents, comments, activity, search

--- a/api/agents.py
+++ b/api/agents.py
@@ -10,7 +10,7 @@ Endpoints:
 
 import json
 from db import get_db, gen_id
-from api import router
+from api import require_permission, router
 from api.validation import validate_text, MAX_NAME_LENGTH
 
 
@@ -72,6 +72,7 @@ def list_agents(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/agents")
+@require_permission("admin")
 def create_agent(params, query, body, headers):
     data = _parse_body(body)
     if data is None:
@@ -139,6 +140,7 @@ def get_agent(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.patch("/api/agents/{id}")
+@require_permission("admin")
 def update_agent(params, query, body, headers):
     agent_id = params["id"].lower()  # normalize path param too
     data = _parse_body(body)

--- a/api/analytics.py
+++ b/api/analytics.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta, timezone
 
 from db import get_db
 from kpi_engine import get_kpi_summary, get_kpi_engine
-from api import router
+from api import require_permission, router
 
 
 @router.get("/api/analytics/kpi")
@@ -288,6 +288,7 @@ def export_analytics(params, query, body, headers):
 
 
 @router.post("/api/analytics/recompute")
+@require_permission("admin")
 def recompute_kpi(params, query, body, headers):
     """Trigger immediate KPI recomputation.
 

--- a/api/auth_keys.py
+++ b/api/auth_keys.py
@@ -12,12 +12,13 @@ Routes:
 import json
 from datetime import datetime, timezone, timedelta
 
-from api import router
+from api import router, require_permission
 from db import get_db, gen_id
 from auth import generate_api_key, hash_key, validate_key_against_db
 
 
 @router.get("/api/auth/keys")
+@require_permission("admin")
 def list_keys(params, query, body, headers):
     """List all API keys. Raw keys are never returned."""
     conn = get_db()
@@ -31,6 +32,7 @@ def list_keys(params, query, body, headers):
 
 
 @router.post("/api/auth/keys")
+@require_permission("admin")
 def create_key(params, query, body, headers):
     """Create a new API key. Returns the raw key exactly once."""
     try:
@@ -39,6 +41,17 @@ def create_key(params, query, body, headers):
         return 400, {"error": "Invalid JSON", "code": "BAD_REQUEST"}
 
     label = data.get("label", "").strip() or "generated"
+    permissions = data.get("permissions", "read,write").strip()
+    rate_limit = data.get("rate_limit")
+    agent = data.get("agent", "").strip()
+
+    # Validate permissions
+    valid_perms = {"read", "write", "admin", "webhook", "analytics"}
+    perm_list = [p.strip() for p in permissions.split(",") if p.strip()]
+    invalid = set(perm_list) - valid_perms
+    if invalid:
+        return 400, {"error": f"Invalid permissions: {', '.join(invalid)}", "code": "BAD_REQUEST"}
+
     raw_key = generate_api_key()
     key_hash = hash_key(raw_key)
     kid = gen_id()
@@ -47,9 +60,9 @@ def create_key(params, query, body, headers):
     conn = get_db()
     try:
         conn.execute(
-            """INSERT INTO api_keys (id, key_hash, label, is_active, created_at)
-               VALUES (?, ?, ?, 1, ?)""",
-            (kid, key_hash, label, now),
+            """INSERT INTO api_keys (id, key_hash, label, is_active, created_at, permissions, agent, rate_limit)
+               VALUES (?, ?, ?, 1, ?, ?, ?, ?)""",
+            (kid, key_hash, label, now, permissions, agent, rate_limit),
         )
         conn.commit()
     except Exception as e:
@@ -63,6 +76,9 @@ def create_key(params, query, body, headers):
     return 201, {
         "id": kid,
         "label": label,
+        "permissions": permissions,
+        "agent": agent,
+        "rate_limit": rate_limit,
         "key": raw_key,  # shown ONLY on creation
         "created_at": now,
         "warning": "Save this key now — it cannot be retrieved again.",
@@ -70,6 +86,7 @@ def create_key(params, query, body, headers):
 
 
 @router.patch("/api/auth/keys/{id}")
+@require_permission("admin")
 def update_key(params, query, body, headers):
     """Update a key's label or deactivate it with optional grace period."""
     try:
@@ -128,6 +145,7 @@ def update_key(params, query, body, headers):
 
 
 @router.delete("/api/auth/keys/{id}")
+@require_permission("admin")
 def delete_key(params, query, body, headers):
     """Permanently delete an API key. Cannot be undone."""
     kid = params.get("id")

--- a/api/comments.py
+++ b/api/comments.py
@@ -9,7 +9,7 @@ Endpoints:
 
 import json
 from db import get_db, gen_id
-from api import router
+from api import require_permission, router
 from api.validation import validate_text, MAX_COMMENT_LENGTH
 
 
@@ -64,6 +64,7 @@ def list_task_comments(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/tasks/{id}/comments")
+@require_permission("write")
 def create_task_comment(params, query, body, headers):
     task_id = params["id"]
     data = _parse_body(body)
@@ -131,6 +132,7 @@ def list_page_comments(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/pages/{id}/comments")
+@require_permission("write")
 def create_page_comment(params, query, body, headers):
     page_id = params["id"]
     data = _parse_body(body)

--- a/api/discussions.py
+++ b/api/discussions.py
@@ -16,7 +16,7 @@ Endpoints:
 import json
 from db import get_db, gen_id
 from activity_logger import log_activity_event, get_actor_from_headers
-from api import router, is_authenticated
+from api import require_permission, router, is_authenticated
 from api.validation import validate_title, validate_text, validate_enum, MAX_TITLE_LENGTH, MAX_COMMENT_LENGTH, VALID_DISCUSSION_STATUSES, VALID_VISIBILITIES, VALID_VERDICTS
 from webhook import on_discussion_created, on_discussion_feedback, on_discussion_closed
 
@@ -153,6 +153,7 @@ def get_discussion(params, query, body, headers):
 
 
 @router.post("/api/discussions")
+@require_permission("write")
 def create_discussion(params, query, body, headers):
     """Create a new discussion.
 
@@ -207,6 +208,7 @@ def create_discussion(params, query, body, headers):
 
 
 @router.patch("/api/discussions/{id}")
+@require_permission("write")
 def update_discussion(params, query, body, headers):
     """Update a discussion.
 
@@ -284,6 +286,7 @@ def update_discussion(params, query, body, headers):
 
 
 @router.delete("/api/discussions/{id}")
+@require_permission("write")
 def delete_discussion(params, query, body, headers):
     """Delete a discussion and all its feedback."""
     discussion_id = params["id"]
@@ -305,6 +308,7 @@ def delete_discussion(params, query, body, headers):
 
 
 @router.post("/api/discussions/{id}/feedback")
+@require_permission("write")
 def add_feedback(params, query, body, headers):
     """Add feedback for a discussion round.
 
@@ -476,6 +480,7 @@ def get_discussion_summary(params, query, body, headers):
 # ── Feedback File Ingestion (standalone feature) ──
 
 @router.post("/api/discussions/ingest")
+@require_permission("write")
 def ingest_feedback_file(params, query, body, headers):
     """Manually ingest a feedback file from disk into the database.
 

--- a/api/export.py
+++ b/api/export.py
@@ -9,7 +9,7 @@ Endpoints:
 import json
 from datetime import datetime, timezone
 from db import get_db, gen_id
-from api import router
+from api import require_permission, router
 
 
 # ---------------------------------------------------------------------------
@@ -158,6 +158,7 @@ def _build_project_export(conn, project_row) -> dict:
 # ---------------------------------------------------------------------------
 
 @router.post("/api/import")
+@require_permission("admin")
 def import_data(params, query, body, headers):
     """Import data from a JSON export.
 

--- a/api/messages.py
+++ b/api/messages.py
@@ -13,7 +13,7 @@ Endpoints:
 
 import json
 from db import get_db, gen_id
-from api import router
+from api import require_permission, router
 from api.validation import validate_text
 
 
@@ -22,6 +22,7 @@ from api.validation import validate_text
 # ---------------------------------------------------------------------------
 
 @router.post("/api/messages")
+@require_permission("write")
 def send_message(params, query, body, headers):
     """Send a message to an agent (or broadcast to all with to_agent='')."""
     data = _parse_msg_body(body)
@@ -127,6 +128,7 @@ def list_messages(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.patch("/api/messages/{id}/read")
+@require_permission("write")
 def mark_read(params, query, body, headers):
     """Mark a message as read."""
     msg_id = params["id"]
@@ -149,6 +151,7 @@ def mark_read(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.patch("/api/messages/read-all")
+@require_permission("write")
 def mark_all_read(params, query, body, headers):
     """Mark all unread messages for an agent as read."""
     agent = headers.get("x-actor", "")
@@ -172,6 +175,7 @@ def mark_all_read(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.delete("/api/messages/{id}")
+@require_permission("write")
 def delete_message(params, query, body, headers):
     """Delete a message."""
     msg_id = params["id"]

--- a/api/pages.py
+++ b/api/pages.py
@@ -12,7 +12,7 @@ Endpoints:
 
 import json
 from db import get_db, gen_id
-from api import router, is_authenticated
+from api import require_permission, router, is_authenticated
 from api.validation import validate_title, validate_text, validate_enum, MAX_TITLE_LENGTH, MAX_CONTENT_LENGTH, VALID_VISIBILITIES
 
 
@@ -137,6 +137,7 @@ def list_all_pages(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/pages")
+@require_permission("write")
 def create_standalone_page(params, query, body, headers):
     """Create a page without a project (project_id = NULL).
 
@@ -247,6 +248,7 @@ def list_pages(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/projects/{slug}/pages")
+@require_permission("write")
 def create_page(params, query, body, headers):
     slug = params["slug"]
     data = _parse_body(body)
@@ -321,6 +323,7 @@ def create_page(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.patch("/api/pages/{id}")
+@require_permission("write")
 def update_page(params, query, body, headers):
     page_id = params["id"]
     data = _parse_body(body)
@@ -408,6 +411,7 @@ def update_page(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.delete("/api/pages/{id}")
+@require_permission("write")
 def delete_page(params, query, body, headers):
     page_id = params["id"]
     actor = headers.get("x-actor", "owner")
@@ -450,6 +454,7 @@ def delete_page(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/pages/{id}/move")
+@require_permission("write")
 def move_page(params, query, body, headers):
     page_id = params["id"]
     data = _parse_body(body)

--- a/api/plans.py
+++ b/api/plans.py
@@ -19,7 +19,7 @@ Endpoints:
 
 import json
 from db import get_db, gen_id
-from api import router
+from api import require_permission, router
 from api.validation import (
     validate_enum, validate_text, validate_steps,
     VALID_PLAN_STATUSES, VALID_STEP_STATUSES,
@@ -258,6 +258,7 @@ def get_plan(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/projects/{slug}/plans")
+@require_permission("write")
 def create_plan(params, query, body, headers):
     """Create a new plan (status=proposed)."""
     slug = params["slug"]
@@ -335,6 +336,7 @@ def create_plan(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.patch("/api/plans/{id}")
+@require_permission("write")
 def update_plan(params, query, body, headers):
     """Update plan fields (description, context, steps, assignee, metadata)."""
     plan_id = params["id"]
@@ -432,6 +434,7 @@ def update_plan(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.delete("/api/plans/{id}")
+@require_permission("write")
 def delete_plan(params, query, body, headers):
     """Delete a plan (only proposed or rejected plans can be deleted)."""
     plan_id = params["id"]
@@ -525,24 +528,28 @@ def _status_transition(plan_id: str, target_status: str, actor: str, body: bytes
 
 
 @router.post("/api/plans/{id}/approve")
+@require_permission("admin")
 def approve_plan(params, query, body, headers):
     """Approve a proposed plan. Optionally update steps in the same call."""
     return _status_transition(params["id"], "approved", headers.get("x-actor", "owner"), body)
 
 
 @router.post("/api/plans/{id}/reject")
+@require_permission("admin")
 def reject_plan(params, query, body, headers):
     """Reject a proposed plan."""
     return _status_transition(params["id"], "rejected", headers.get("x-actor", "owner"))
 
 
 @router.post("/api/plans/{id}/execute")
+@require_permission("admin")
 def execute_plan(params, query, body, headers):
     """Start executing an approved plan."""
     return _status_transition(params["id"], "executing", headers.get("x-actor", "owner"), body)
 
 
 @router.post("/api/plans/{id}/complete")
+@require_permission("admin")
 def complete_plan(params, query, body, headers):
     """Mark an executing plan as done."""
     return _status_transition(params["id"], "done", headers.get("x-actor", "owner"))
@@ -553,6 +560,7 @@ def complete_plan(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/plans/{id}/step/{index}")
+@require_permission("write")
 def update_step(params, query, body, headers):
     """Update the status/result of a single step within an executing plan.
 

--- a/api/projects.py
+++ b/api/projects.py
@@ -14,7 +14,7 @@ Endpoints:
 
 import json
 from db import get_db, gen_id, slugify
-from api import router, is_authenticated
+from api import require_permission, router, is_authenticated
 from api.validation import validate_title, validate_text, validate_enum, MAX_TITLE_LENGTH, MAX_DESCRIPTION_LENGTH, MAX_NAME_LENGTH, VALID_VISIBILITIES
 from event_bus import publish
 
@@ -139,6 +139,7 @@ def get_project(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/projects")
+@require_permission("admin")
 def create_project(params, query, body, headers):
     data = _parse_body(body)
     if data is None:
@@ -234,6 +235,7 @@ def create_project(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.patch("/api/projects/{slug}")
+@require_permission("admin")
 def update_project(params, query, body, headers):
     slug = params["slug"]
     data = _parse_body(body)
@@ -334,6 +336,7 @@ def update_project(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.delete("/api/projects/{slug}")
+@require_permission("admin")
 def archive_project(params, query, body, headers):
     slug = params["slug"]
     actor = headers.get("x-actor", "owner")
@@ -371,6 +374,7 @@ def archive_project(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/projects/{slug}/restore")
+@require_permission("write")
 def restore_project(params, query, body, headers):
     slug = params["slug"]
     actor = headers.get("x-actor", "owner")

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -13,7 +13,7 @@ Endpoints:
 
 import json
 from db import get_db, gen_id
-from api import router
+from api import require_permission, router
 from api.validation import (
     validate_enum, validate_title, validate_text, validate_task_type,
     VALID_STATUSES, VALID_PRIORITIES,
@@ -220,6 +220,7 @@ def list_project_tasks(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/projects/{slug}/tasks")
+@require_permission("write")
 def create_task(params, query, body, headers):
     slug = params["slug"]
     data = _parse_body(body)
@@ -332,6 +333,7 @@ def create_task(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.patch("/api/tasks/{id}")
+@require_permission("write")
 def update_task(params, query, body, headers):
     task_id = params["id"]
     data = _parse_body(body)
@@ -557,6 +559,7 @@ def update_task(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.delete("/api/tasks/{id}")
+@require_permission("write")
 def delete_task(params, query, body, headers):
     task_id = params["id"]
     actor = headers.get("x-actor", "owner")

--- a/api/webhook_task.py
+++ b/api/webhook_task.py
@@ -28,7 +28,7 @@ Rate limit: 60 requests/minute per agent (in-memory)
 import json
 import time
 from db import get_db
-from api import router
+from api import require_permission, router
 
 # ── Simple in-memory rate limiter ──────────────────────────────────────
 _rate_limits: dict[str, list[float]] = {}
@@ -53,6 +53,7 @@ VALID_STATUSES = {"todo", "proposed", "in_progress", "review", "done"}
 
 
 @router.post("/api/webhook/task-update")
+@require_permission("webhook")
 def webhook_task_update(params, query, body, headers):
     """Receive task status update from an agent."""
     try:
@@ -211,6 +212,7 @@ def _get_or_create_default_project(conn, agent_id: str) -> str | None:
 
 
 @router.post("/api/webhook/agent-event")
+@require_permission("webhook")
 def webhook_agent_event(params, query, body, headers):
     """Receive agent lifecycle event — auto-create or update tasks.
 
@@ -385,6 +387,7 @@ def webhook_agent_event(params, query, body, headers):
 # ---------------------------------------------------------------------------
 
 @router.post("/api/webhook/plan-create")
+@require_permission("webhook")
 def webhook_plan_create(params, query, body, headers):
     """Receive plan creation from an agent.
 

--- a/auth.py
+++ b/auth.py
@@ -78,9 +78,9 @@ def _ensure_db_key():
         kid = gen_id()
         now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         conn.execute(
-            """INSERT INTO api_keys (id, key_hash, label, is_active, created_at)
-               VALUES (?, ?, ?, 1, ?)""",
-            (kid, key_hash, "imported", now),
+            """INSERT INTO api_keys (id, key_hash, label, is_active, created_at, permissions, rate_limit)
+               VALUES (?, ?, ?, 1, ?, ?, ?)""",
+            (kid, key_hash, "imported", now, "read,write,admin", 0),
         )
         conn.commit()
         conn.close()
@@ -97,9 +97,9 @@ def _ensure_db_key():
     kid = gen_id()
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     conn.execute(
-        """INSERT INTO api_keys (id, key_hash, label, is_active, created_at)
-           VALUES (?, ?, ?, 1, ?)""",
-        (kid, key_hash, "default", now),
+        """INSERT INTO api_keys (id, key_hash, label, is_active, created_at, permissions, rate_limit)
+           VALUES (?, ?, ?, 1, ?, ?, ?)""",
+        (kid, key_hash, "default", now, "read,write,admin", 0),
     )
     conn.commit()
     conn.close()
@@ -113,7 +113,10 @@ def validate_key_against_db(raw_key: str) -> tuple:
     until their grace_until timestamp passes.
 
     Returns:
-        (is_valid: bool, key_id: str|None)
+        (is_valid: bool, key_id: str|None, permissions: str, agent: str, rate_limit: int)
+        permissions is comma-separated (e.g. "read,write"), defaults to "read,write".
+        agent is the agent label (e.g. "pi"), defaults to "".
+        rate_limit is requests per window (0 = unlimited), defaults to 60.
     """
     key_hash = hash_key(raw_key)
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -121,7 +124,7 @@ def validate_key_against_db(raw_key: str) -> tuple:
 
     # Check active keys
     row = conn.execute(
-        """SELECT id FROM api_keys
+        """SELECT id, permissions, agent, rate_limit FROM api_keys
            WHERE key_hash = ? AND is_active = 1""",
         (key_hash,),
     ).fetchone()
@@ -134,11 +137,11 @@ def validate_key_against_db(raw_key: str) -> tuple:
         )
         conn.commit()
         conn.close()
-        return True, row["id"]
+        return True, row["id"], row["permissions"] or "read,write", row["agent"] or "", row["rate_limit"] if row["rate_limit"] is not None else 60
 
     # Check grace period keys
     row = conn.execute(
-        """SELECT id FROM api_keys
+        """SELECT id, permissions, agent, rate_limit FROM api_keys
            WHERE key_hash = ? AND is_active = 0
            AND grace_until IS NOT NULL AND grace_until > ?""",
         (key_hash, now),
@@ -146,9 +149,9 @@ def validate_key_against_db(raw_key: str) -> tuple:
 
     conn.close()
     if row:
-        return True, row["id"]
+        return True, row["id"], row["permissions"] or "read,write", row["agent"] or "", row["rate_limit"] if row["rate_limit"] is not None else 60
 
-    return False, None
+    return False, None, "", "", 60
 
 
 def validate_key(raw_key: str, stored_hash: str) -> bool:
@@ -181,15 +184,15 @@ def check_auth_multi(headers: dict) -> tuple:
     """Check auth using the multi-key database path.
 
     Returns:
-        (is_valid: bool, key_id: str|None)
+        (is_valid: bool, key_id: str|None, permissions: str, agent: str, rate_limit: int)
     """
     auth_header = headers.get("authorization", "")
-    if not auth_header.startswith("Bearer "):
-        return False, None
-    token = auth_header[7:]
-    if len(token) > 1024:
-        return False, None
-    return validate_key_against_db(token)
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+        if len(token) > 1024:
+            return False, None, "", "", 60
+        return validate_key_against_db(token)
+    return False, None, "", "", 60
 
 
 def has_db_keys() -> bool:

--- a/config.py
+++ b/config.py
@@ -79,6 +79,11 @@ DEFAULTS = {
         "max_steps": 50,                        # max steps per plan
         "default_assignee": "",                 # fallback assignee if not specified
     },
+    "rate_limit": {
+        "default": 60,          # requests per window per key (0 = unlimited)
+        "burst": 10,            # max requests per second
+        "window_seconds": 60,   # sliding window duration
+    },
     "agents": {
         # agent_id → project_slug mapping for auto-tracking
         # Agent events will route to the corresponding project

--- a/db.py
+++ b/db.py
@@ -18,7 +18,7 @@ from config import get_config
 
 DB_PATH = None  # set on first get_db() call
 
-SCHEMA_VERSION = 14
+SCHEMA_VERSION = 15
 
 SCHEMA_SQL = """
 PRAGMA journal_mode = WAL;
@@ -593,6 +593,11 @@ ALTER TABLE plans ADD COLUMN step_results TEXT DEFAULT '[]';
         14: """-- Schema v14: git_branch column for branch-per-task tracking
 ALTER TABLE tasks ADD COLUMN git_branch TEXT DEFAULT '';
 CREATE INDEX IF NOT EXISTS idx_tasks_git_branch ON tasks(git_branch);
+    """,
+        15: """-- Schema v15: rate_limit column for per-key rate limiting + promote existing keys to admin
+ALTER TABLE api_keys ADD COLUMN rate_limit INTEGER DEFAULT 60;
+-- Promote all existing keys to read,write,admin for backward compatibility
+UPDATE api_keys SET permissions = 'read,write,admin' WHERE permissions = 'read,write';
     """,
     }
     for ver in range(from_ver + 1, to_ver + 1):

--- a/rate_limiter.py
+++ b/rate_limiter.py
@@ -1,0 +1,178 @@
+"""rate_limiter.py — In-memory sliding window rate limiter for AgentBoard.
+
+Tracks request counts per API key (and optional per-IP) using a fixed-window
+counter that auto-expires. Zero external dependencies — pure Python dict + time.
+
+Usage:
+    from rate_limiter import RateLimiter
+
+    limiter = RateLimiter(default_limit=60, burst=10)
+
+    # Check if request is allowed
+    allowed = limiter.check("key_id_abc")
+    if not allowed:
+        retry_after = limiter.retry_after("key_id_abc")
+"""
+
+import threading
+import time
+
+# Sentinel value: rate_limit=0 in DB means unlimited
+_UNLIMITED = 0
+
+
+class RateLimiter:
+    """Thread-safe in-memory sliding window rate limiter.
+
+    Each key_id gets a counter that resets after `window_seconds`.
+    A burst check prevents more than `burst` requests in any 1-second period.
+    """
+
+    def __init__(self, default_limit: int = 60, burst: int = 10,
+                 window_seconds: int = 60, cleanup_interval: int = 60):
+        """Initialize rate limiter.
+
+        Args:
+            default_limit: Max requests per window per key (0 = unlimited).
+            burst: Max requests in any 1-second period.
+            window_seconds: Window duration in seconds.
+            cleanup_interval: Seconds between stale entry cleanup.
+        """
+        self.default_limit = default_limit
+        self.burst = burst
+        self.window_seconds = window_seconds
+        self.cleanup_interval = cleanup_interval
+
+        # {key_id: {"count": int, "window_start": float, "second_count": int, "second_start": float}}
+        self._buckets: dict = {}
+        self._lock = threading.Lock()
+
+        # Per-key overrides: {key_id: limit} — 0 means unlimited
+        self._key_limits: dict = {}
+
+        # Start background cleanup thread
+        self._stop_event = threading.Event()
+        self._cleaner = threading.Thread(target=self._cleanup_loop, daemon=True)
+        self._cleaner.start()
+
+    def set_key_limit(self, key_id: str, limit: int):
+        """Set per-key rate limit override. 0 = unlimited (stored as override)."""
+        with self._lock:
+            self._key_limits[key_id] = limit
+
+    def get_effective_limit(self, key_id: str) -> int:
+        """Get the effective rate limit for a key."""
+        with self._lock:
+            return self._key_limits.get(key_id, self.default_limit)
+
+    def check(self, key_id: str) -> bool:
+        """Check if a request from key_id is allowed.
+
+        Returns True if the request should be allowed, False if rate limited.
+        This is NOT idempotent — each call increments the counter.
+        """
+        limit = self.get_effective_limit(key_id)
+        if limit == _UNLIMITED:
+            return True
+
+        now = time.time()
+        with self._lock:
+            bucket = self._buckets.get(key_id)
+
+            if bucket is None or (now - bucket["window_start"]) >= self.window_seconds:
+                # New window
+                self._buckets[key_id] = {
+                    "count": 1,
+                    "window_start": now,
+                    "second_count": 1,
+                    "second_start": now,
+                }
+                return True
+
+            # Check window limit
+            if bucket["count"] >= limit:
+                return False
+
+            # Check burst limit (per-second)
+            if now - bucket["second_start"] >= 1.0:
+                bucket["second_count"] = 0
+                bucket["second_start"] = now
+
+            if bucket["second_count"] >= self.burst:
+                return False
+
+            # Allow request
+            bucket["count"] += 1
+            bucket["second_count"] += 1
+            return True
+
+    def retry_after(self, key_id: str) -> int:
+        """Get seconds until the key can make another request."""
+        limit = self.get_effective_limit(key_id)
+        if limit == _UNLIMITED:
+            return 0
+
+        now = time.time()
+        with self._lock:
+            bucket = self._buckets.get(key_id)
+            if bucket is None:
+                return 0
+
+            window_remaining = self.window_seconds - (now - bucket["window_start"])
+            second_remaining = 1.0 - (now - bucket["second_start"])
+
+            if window_remaining <= 0 and second_remaining <= 0:
+                return 0
+
+            return max(1, int(max(window_remaining, second_remaining)))
+
+    def get_headers(self, key_id: str) -> dict:
+        """Get X-RateLimit-* headers for a response."""
+        limit = self.get_effective_limit(key_id)
+        if limit == _UNLIMITED:
+            return {
+                "X-RateLimit-Limit": "unlimited",
+                "X-RateLimit-Remaining": "unlimited",
+                "X-RateLimit-Reset": "0",
+            }
+
+        now = time.time()
+        with self._lock:
+            bucket = self._buckets.get(key_id)
+            if bucket is None:
+                remaining = limit
+                reset_at = int(now + self.window_seconds)
+            else:
+                remaining = max(0, limit - bucket["count"])
+                reset_at = int(bucket["window_start"] + self.window_seconds)
+
+        return {
+            "X-RateLimit-Limit": str(limit),
+            "X-RateLimit-Remaining": str(remaining),
+            "X-RateLimit-Reset": str(reset_at),
+        }
+
+    def reset(self, key_id: str):
+        """Reset rate limit counter for a key (e.g., after testing)."""
+        with self._lock:
+            self._buckets.pop(key_id, None)
+
+    def _cleanup_loop(self):
+        """Background thread: periodically remove expired entries."""
+        while not self._stop_event.wait(self.cleanup_interval):
+            self._cleanup()
+
+    def _cleanup(self):
+        """Remove expired buckets to prevent memory growth."""
+        now = time.time()
+        with self._lock:
+            expired = [
+                kid for kid, b in self._buckets.items()
+                if (now - b["window_start"]) >= self.window_seconds * 2
+            ]
+            for kid in expired:
+                del self._buckets[kid]
+
+    def stop(self):
+        """Stop the cleanup thread. Call on shutdown."""
+        self._stop_event.set()

--- a/server.py
+++ b/server.py
@@ -20,13 +20,14 @@ from http.server import HTTPServer, BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse, parse_qs
 from pathlib import Path
 
-VERSION = "0.7.0"
+VERSION = "0.7.1"
 
 # Local imports
 from config import get_config
 from db import get_db
 from auth import get_or_create_api_key, hash_key, check_auth, check_auth_multi, has_db_keys, _ensure_db_key
 from kpi_engine import KPIEngine
+from rate_limiter import RateLimiter
 
 BASE_DIR = Path(__file__).parent
 STATIC_DIR = BASE_DIR / "static"
@@ -34,6 +35,9 @@ STATIC_DIR = BASE_DIR / "static"
 # Lazy-loaded API router (may not exist yet during early development)
 _api_router = None
 _api_router_error = None
+
+# Global rate limiter — initialized with config defaults in main()
+rate_limiter: RateLimiter = None  # type: ignore[assignment]
 
 
 def _get_api_router():
@@ -147,12 +151,30 @@ class RequestHandler(BaseHTTPRequestHandler):
         if needs_auth:
             # Try multi-key auth first (schema v3), fallback to legacy single-key
             if has_db_keys():
-                valid, _ = check_auth_multi(self.headers)
+                valid, key_id, permissions, agent_label, key_rate_limit = check_auth_multi(self.headers)
                 if not valid:
                     self._json_response(
                         {"error": "Unauthorized", "code": "UNAUTHORIZED"}, 401
                     )
                     return
+                # Inject key metadata into headers for downstream handlers
+                self.headers["x-auth-valid"] = "true"
+                self.headers["x-key-id"] = key_id or ""
+                self.headers["x-key-permissions"] = permissions
+                self.headers["x-key-agent"] = agent_label
+                # Sync per-key rate limit from DB
+                if rate_limiter and key_id:
+                    rate_limiter.set_key_limit(key_id, key_rate_limit)
+                # Rate limit check
+                if rate_limiter and key_id:
+                    if not rate_limiter.check(key_id):
+                        retry = rate_limiter.retry_after(key_id)
+                        self._json_response(
+                            {"error": "Rate limit exceeded", "code": "RATE_LIMITED",
+                             "retry_after": retry},
+                            429,
+                        )
+                        return
             else:
                 api_key_hash = hash_key(get_or_create_api_key())
                 if not check_auth(self.headers, api_key_hash):
@@ -160,20 +182,23 @@ class RequestHandler(BaseHTTPRequestHandler):
                         {"error": "Unauthorized", "code": "UNAUTHORIZED"}, 401
                     )
                     return
-
-        # Pass auth status to API handlers via internal header
-        # (false = public/unauthenticated request, true = authenticated)
-        if needs_auth:
-            self.headers["x-auth-valid"] = "true"
+                self.headers["x-auth-valid"] = "true"
+                self.headers["x-key-id"] = ""
+                self.headers["x-key-permissions"] = "read,write,admin"
+                self.headers["x-key-agent"] = ""
         else:
             # For public routes, still validate auth if provided —
             # handlers use x-auth-valid to decide visibility (e.g. hidden discussions)
             if has_db_keys():
-                valid, _ = check_auth_multi(self.headers)
+                valid, key_id, permissions, agent_label, key_rate_limit = check_auth_multi(self.headers)
             else:
                 api_key_hash = hash_key(get_or_create_api_key())
                 valid = check_auth(self.headers, api_key_hash)
+                key_id, permissions, agent_label = "", "", ""
             self.headers["x-auth-valid"] = "true" if valid else "false"
+            self.headers["x-key-id"] = key_id if valid else ""
+            self.headers["x-key-permissions"] = permissions if valid else "read"
+            self.headers["x-key-agent"] = agent_label if valid else ""
 
         # API routes
         self._handle_api(method, path, query)
@@ -236,6 +261,11 @@ class RequestHandler(BaseHTTPRequestHandler):
         self._send_cors_headers()
         self.send_header("Content-Type", "application/json")
         self.send_header("Cache-Control", "no-store")
+        # Inject rate limit headers for authenticated requests
+        key_id = self.headers.get("x-key-id", "")
+        if rate_limiter and key_id:
+            for hdr, val in rate_limiter.get_headers(key_id).items():
+                self.send_header(hdr, val)
         self.end_headers()
         self.wfile.write(json.dumps(data, ensure_ascii=False).encode("utf-8"))
 
@@ -369,6 +399,15 @@ def main():
     # Ensure database exists and is migrated
     get_db()
 
+    # Initialize global rate limiter from config
+    global rate_limiter
+    rl_cfg = cfg.get("rate_limit", {})
+    rate_limiter = RateLimiter(
+        default_limit=rl_cfg.get("default", 60),
+        burst=rl_cfg.get("burst", 10),
+        window_seconds=rl_cfg.get("window_seconds", 60),
+    )
+
     # Ensure at least one API key exists in DB (imports legacy key on first run)
     _ensure_db_key()
 
@@ -464,6 +503,8 @@ def main():
     except KeyboardInterrupt:
         print("\nShutting down.")
         kpi.stop()
+        if rate_limiter:
+            rate_limiter.stop()
         if fb_watcher:
             fb_watcher.stop()
         server.server_close()

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,323 @@
+"""Tests for AgentBoard permission system (key scoping)."""
+
+import json
+import os
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+
+class TestPermissions:
+    """Test permission decorator and helper functions in api/__init__.py."""
+
+    def _make_headers(self, auth_valid=True, permissions="read,write"):
+        return {
+            "x-auth-valid": "true" if auth_valid else "false",
+            "x-key-permissions": permissions,
+            "x-key-id": "test-key-id",
+        }
+
+    def test_is_authenticated_true(self):
+        from api import is_authenticated
+        assert is_authenticated(self._make_headers()) is True
+
+    def test_is_authenticated_false(self):
+        from api import is_authenticated
+        assert is_authenticated(self._make_headers(auth_valid=False)) is False
+
+    def test_get_permissions(self):
+        from api import get_permissions
+        perms = get_permissions(self._make_headers(permissions="read,write,admin"))
+        assert perms == ["read", "write", "admin"]
+
+    def test_get_permissions_single(self):
+        from api import get_permissions
+        perms = get_permissions(self._make_headers(permissions="read"))
+        assert perms == ["read"]
+
+    def test_get_permissions_empty(self):
+        from api import get_permissions
+        perms = get_permissions(self._make_headers(permissions=""))
+        assert perms == []
+
+    def test_has_permission_read(self):
+        from api import has_permission
+        headers = self._make_headers(permissions="read,write")
+        assert has_permission(headers, "read") is True
+        assert has_permission(headers, "write") is True
+        assert has_permission(headers, "admin") is False
+
+    def test_has_permission_admin_includes_all(self):
+        from api import has_permission
+        headers = self._make_headers(permissions="admin")
+        assert has_permission(headers, "read") is True
+        assert has_permission(headers, "write") is True
+        assert has_permission(headers, "admin") is True
+
+    def test_has_permission_webhook(self):
+        from api import has_permission
+        headers = self._make_headers(permissions="read,webhook")
+        assert has_permission(headers, "webhook") is True
+        assert has_permission(headers, "write") is False
+
+    def test_require_permission_granted(self):
+        from api import require_permission
+
+        @require_permission("write")
+        def handler(params, query, body, headers):
+            return 200, {"ok": True}
+
+        result = handler({}, {}, b"", self._make_headers(permissions="read,write"))
+        assert result == (200, {"ok": True})
+
+    def test_require_permission_denied(self):
+        from api import require_permission
+
+        @require_permission("admin")
+        def handler(params, query, body, headers):
+            return 200, {"ok": True}
+
+        result = handler({}, {}, b"", self._make_headers(permissions="read,write"))
+        assert result[0] == 403
+        assert result[1]["code"] == "FORBIDDEN"
+
+    def test_require_permission_multiple(self):
+        from api import require_permission
+
+        @require_permission("write", "admin")
+        def handler(params, query, body, headers):
+            return 200, {"ok": True}
+
+        # write only — should fail (needs both write AND admin)
+        result = handler({}, {}, b"", self._make_headers(permissions="read,write"))
+        assert result[0] == 403
+
+        # write + admin — should pass
+        result = handler({}, {}, b"", self._make_headers(permissions="read,write,admin"))
+        assert result[0] == 200
+
+    def test_require_permission_skip_unauthenticated(self):
+        from api import require_permission
+
+        @require_permission("admin")
+        def handler(params, query, body, headers):
+            return 200, {"ok": True}
+
+        # Unauthenticated request — decorator should skip check
+        # (server.py already blocks unauthenticated write requests)
+        result = handler({}, {}, b"", self._make_headers(auth_valid=False))
+        assert result[0] == 200
+
+
+class TestAuthPermissions:
+    """Test auth.py returning permissions from validate_key_against_db."""
+
+    @classmethod
+    def setup_class(cls):
+        """Create in-memory DB with api_keys for testing."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("""CREATE TABLE IF NOT EXISTS api_keys (
+            id TEXT PRIMARY KEY,
+            key_hash TEXT NOT NULL UNIQUE,
+            label TEXT DEFAULT 'default',
+            is_active INTEGER DEFAULT 1,
+            created_at TEXT DEFAULT (datetime('now')),
+            last_used_at TEXT,
+            grace_until TEXT,
+            agent TEXT DEFAULT '',
+            permissions TEXT DEFAULT 'read,write',
+            rate_limit INTEGER DEFAULT 60
+        )""")
+        conn.commit()
+
+        # Insert test keys
+        import hashlib
+        cls.key_admin = "ab_test_admin_key_1234567890"
+        cls.key_read = "ab_test_read_only_key_123456"
+        cls.key_inactive = "ab_test_inactive_key_1234"
+
+        conn.execute(
+            "INSERT INTO api_keys (id, key_hash, label, is_active, permissions, agent) VALUES (?, ?, ?, ?, ?, ?)",
+            ("admin-key", hashlib.sha256(cls.key_admin.encode()).hexdigest(), "admin-key", 1, "read,write,admin", "cto"),
+        )
+        conn.execute(
+            "INSERT INTO api_keys (id, key_hash, label, is_active, permissions, agent) VALUES (?, ?, ?, ?, ?, ?)",
+            ("read-key", hashlib.sha256(cls.key_read.encode()).hexdigest(), "read-key", 1, "read", "viewer"),
+        )
+        conn.execute(
+            "INSERT INTO api_keys (id, key_hash, label, is_active, permissions, agent) VALUES (?, ?, ?, ?, ?, ?)",
+            ("inactive-key", hashlib.sha256(cls.key_inactive.encode()).hexdigest(), "inactive-key", 0, "read", "old"),
+        )
+
+        conn.commit()
+        conn.close()
+
+        # Monkey-patch get_db to return our test connection
+        from db import get_db
+        cls._original_get_db = get_db
+
+        def mock_get_db():
+            c = sqlite3.connect(":memory:")
+            c.row_factory = sqlite3.Row
+            c.execute("PRAGMA journal_mode = WAL")
+            c.execute("""CREATE TABLE IF NOT EXISTS api_keys (
+                id TEXT PRIMARY KEY,
+                key_hash TEXT NOT NULL UNIQUE,
+                label TEXT DEFAULT 'default',
+                is_active INTEGER DEFAULT 1,
+                created_at TEXT DEFAULT (datetime('now')),
+                last_used_at TEXT,
+                grace_until TEXT,
+                agent TEXT DEFAULT '',
+                permissions TEXT DEFAULT 'read,write',
+                rate_limit INTEGER DEFAULT 60
+            )""")
+            c.commit()
+            import hashlib
+            c.execute("INSERT INTO api_keys (id, key_hash, label, is_active, permissions, agent) VALUES (?, ?, ?, ?, ?, ?)",
+                ("admin-key", hashlib.sha256("ab_test_admin_key_1234567890".encode()).hexdigest(), "admin-key", 1, "read,write,admin", "cto"))
+            c.execute("INSERT INTO api_keys (id, key_hash, label, is_active, permissions, agent) VALUES (?, ?, ?, ?, ?, ?)",
+                ("read-key", hashlib.sha256("ab_test_read_only_key_123456".encode()).hexdigest(), "read-key", 1, "read", "viewer"))
+            c.commit()
+            return c
+
+        # Can't easily monkey-patch module-level get_db, so we test via auth module directly
+        import auth
+        cls._original_auth_get_db = auth.get_db
+        auth.get_db = mock_get_db
+
+    @classmethod
+    def teardown_class(cls):
+        import auth
+        auth.get_db = cls._original_auth_get_db
+
+    def test_validate_key_returns_permissions(self):
+        from auth import validate_key_against_db
+        valid, key_id, perms, agent, rl = validate_key_against_db("ab_test_admin_key_1234567890")
+        assert valid is True
+        assert key_id == "admin-key"
+        assert "admin" in perms
+        assert agent == "cto"
+
+    def test_validate_key_read_only(self):
+        from auth import validate_key_against_db
+        valid, key_id, perms, agent, rl = validate_key_against_db("ab_test_read_only_key_123456")
+        assert valid is True
+        assert perms == "read"
+        assert agent == "viewer"
+
+    def test_validate_key_invalid(self):
+        from auth import validate_key_against_db
+        valid, key_id, perms, agent, rl = validate_key_against_db("ab_nonexistent_key")
+        assert valid is False
+        assert key_id is None
+        assert perms == ""
+        assert agent == ""
+
+    def test_validate_key_inactive(self):
+        from auth import validate_key_against_db
+        # Inactive key without grace period should fail
+        valid, _, _, _, _ = validate_key_against_db("ab_test_inactive_key_1234")
+        assert valid is False
+
+
+class TestAuthKeysCRUD:
+    """Test auth_keys API with permissions support."""
+
+    @classmethod
+    def setup_class(cls):
+        """Create in-memory DB for API key CRUD tests."""
+        # Use a file-based temp DB to avoid shared in-memory DB issues
+        import tempfile
+        cls._db_path = os.path.join(tempfile.gettempdir(), f"test_auth_keys_crud_{id(cls)}.db")
+        if os.path.exists(cls._db_path):
+            os.unlink(cls._db_path)
+        conn = sqlite3.connect(cls._db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("""CREATE TABLE IF NOT EXISTS api_keys (
+            id TEXT PRIMARY KEY,
+            key_hash TEXT NOT NULL UNIQUE,
+            label TEXT DEFAULT 'default',
+            is_active INTEGER DEFAULT 1,
+            created_at TEXT DEFAULT (datetime('now')),
+            last_used_at TEXT,
+            grace_until TEXT,
+            agent TEXT DEFAULT '',
+            permissions TEXT DEFAULT 'read,write',
+            rate_limit INTEGER DEFAULT 60
+        )""")
+        conn.commit()
+
+        # Insert a seed admin key for auth
+        import hashlib
+        seed_hash = hashlib.sha256("ab_seed_admin_key".encode()).hexdigest()
+        conn.execute("INSERT INTO api_keys (id, key_hash, label, is_active, permissions) VALUES (?, ?, ?, ?, ?)",
+                     ("seed-admin", seed_hash, "seed", 1, "read,write,admin"))
+        conn.commit()
+
+        cls.conn = conn
+        cls._db_path_for_mock = cls._db_path  # save for lambda
+        import db
+        cls._orig_get_db = db.get_db
+        # Return a fresh connection each time since handlers call conn.close()
+        db.get_db = lambda: sqlite3.connect(cls._db_path_for_mock)
+        import auth
+        cls._orig_auth_get_db = auth.get_db
+        auth.get_db = lambda: sqlite3.connect(cls._db_path_for_mock)
+        # Also patch api.auth_keys which already imported get_db at load time
+        import api.auth_keys as _ak
+        cls._orig_ak_get_db = _ak.get_db
+        _ak.get_db = lambda: sqlite3.connect(cls._db_path_for_mock)
+
+    @classmethod
+    def teardown_class(cls):
+        import db, auth, api.auth_keys as _ak
+        db.get_db = cls._orig_get_db
+        auth.get_db = cls._orig_auth_get_db
+        _ak.get_db = cls._orig_ak_get_db
+        cls.conn.close()
+        if hasattr(cls, '_db_path') and os.path.exists(cls._db_path):
+            os.unlink(cls._db_path)
+
+    def test_create_key_with_permissions(self):
+        from api.auth_keys import create_key
+        headers = self._admin_headers()
+        body = json.dumps({
+            "label": "test-key",
+            "permissions": "read",
+            "agent": "pi",
+            "rate_limit": 120,
+        }).encode()
+        status, data = create_key({}, {}, body, headers)
+        assert status == 201
+        assert data["permissions"] == "read"
+        assert data["agent"] == "pi"
+        assert data["rate_limit"] == 120
+        assert "key" in data  # raw key returned
+
+    def test_create_key_default_permissions(self):
+        from api.auth_keys import create_key
+        headers = self._admin_headers()
+        body = json.dumps({"label": "default-perms"}).encode()
+        status, data = create_key({}, {}, body, headers)
+        assert status == 201
+        assert data["permissions"] == "read,write"
+
+    def test_create_key_invalid_permissions(self):
+        from api.auth_keys import create_key
+        headers = self._admin_headers()
+        body = json.dumps({"label": "bad", "permissions": "read,superadmin"}).encode()
+        status, data = create_key({}, {}, body, headers)
+        assert status == 400
+        assert "Invalid permissions" in data["error"]
+
+    def _admin_headers(self):
+        return {
+            "x-auth-valid": "true",
+            "x-key-permissions": "read,write,admin",
+            "x-key-id": "seed-admin",
+        }

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,165 @@
+"""Tests for AgentBoard rate limiter module."""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+
+class TestRateLimiter:
+    """Test rate_limiter.py — sliding window rate limiter."""
+
+    def test_basic_allow(self):
+        """First request should always be allowed."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=60, burst=10)
+        assert rl.check("key-1") is True
+
+    def test_window_limit(self):
+        """Requests should be blocked after exceeding window limit."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=3, burst=10, window_seconds=60)
+        assert rl.check("key-2") is True
+        assert rl.check("key-2") is True
+        assert rl.check("key-2") is True
+        assert rl.check("key-2") is False  # 4th request blocked
+
+    def test_burst_limit(self):
+        """Requests should be blocked after exceeding burst limit per second."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=100, burst=2, window_seconds=60)
+        assert rl.check("key-3") is True
+        assert rl.check("key-3") is True
+        assert rl.check("key-3") is False  # 3rd request in same second blocked
+
+    def test_unlimited_key(self):
+        """Key with rate_limit=0 should never be rate limited."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=3, burst=2)
+        rl.set_key_limit("unlimited-key", 0)
+        for _ in range(100):
+            assert rl.check("unlimited-key") is True
+
+    def test_per_key_limit(self):
+        """Per-key limit override should work independently."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=100, burst=10)
+        rl.set_key_limit("restricted-key", 2)
+        assert rl.check("restricted-key") is True
+        assert rl.check("restricted-key") is True
+        assert rl.check("restricted-key") is False
+        # Other keys should still have default limit
+        assert rl.check("other-key") is True
+
+    def test_isolated_keys(self):
+        """Different keys should have independent counters."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=2, burst=10, window_seconds=60)
+        assert rl.check("key-a") is True
+        assert rl.check("key-a") is True
+        assert rl.check("key-a") is False  # key-a exhausted
+        assert rl.check("key-b") is True   # key-b still has capacity
+
+    def test_retry_after(self):
+        """retry_after should return positive int when rate limited."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=1, burst=10, window_seconds=60)
+        rl.check("key-ra")
+        rl.check("key-ra")  # will be blocked
+        retry = rl.retry_after("key-ra")
+        assert retry > 0
+        assert retry <= 60
+
+    def test_retry_after_unlimited(self):
+        """retry_after should return 0 for unlimited keys."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=3)
+        rl.set_key_limit("unlimited", 0)
+        assert rl.retry_after("unlimited") == 0
+
+    def test_get_headers(self):
+        """get_headers should return X-RateLimit-* dict."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=100, burst=10)
+        headers = rl.get_headers("key-h")
+        assert "X-RateLimit-Limit" in headers
+        assert "X-RateLimit-Remaining" in headers
+        assert "X-RateLimit-Reset" in headers
+
+    def test_get_headers_unlimited(self):
+        """get_headers for unlimited key should return 'unlimited'."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=100)
+        rl.set_key_limit("unlimited", 0)
+        headers = rl.get_headers("unlimited")
+        assert headers["X-RateLimit-Limit"] == "unlimited"
+        assert headers["X-RateLimit-Remaining"] == "unlimited"
+
+    def test_reset(self):
+        """reset should clear counter for a key."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=1, burst=10)
+        rl.check("key-reset")
+        assert rl.check("key-reset") is False
+        rl.reset("key-reset")
+        assert rl.check("key-reset") is True
+
+    def test_get_effective_limit(self):
+        """get_effective_limit should return per-key override or default."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=50)
+        assert rl.get_effective_limit("normal") == 50
+        rl.set_key_limit("custom", 100)
+        assert rl.get_effective_limit("custom") == 100
+        rl.set_key_limit("unlim", 0)
+        assert rl.get_effective_limit("unlim") == 0
+
+    def test_set_key_limit_remove_override(self):
+        """Setting rate_limit to 0 should mark key as unlimited."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=10)
+        rl.set_key_limit("key", 5)
+        assert rl.get_effective_limit("key") == 5
+        rl.set_key_limit("key", 0)  # set to unlimited
+        assert rl.get_effective_limit("key") == 0  # 0 = unlimited
+
+    def test_cleanup(self):
+        """Cleanup should remove expired entries."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=1, burst=10, window_seconds=1, cleanup_interval=1)
+        rl.check("expire-key")
+        rl.check("expire-key")  # blocked
+        time.sleep(2.5)
+        rl._cleanup()
+        # After cleanup, bucket should be gone
+        assert "expire-key" not in rl._buckets
+
+    def test_stop(self):
+        """stop() should terminate cleanup thread without error."""
+        from rate_limiter import RateLimiter
+        rl = RateLimiter(default_limit=60)
+        rl.stop()
+        # Should not raise
+        rl.stop()  # idempotent
+
+    def test_thread_safety(self):
+        """Concurrent checks should not corrupt state."""
+        from rate_limiter import RateLimiter
+        import threading
+        rl = RateLimiter(default_limit=1000, burst=100)
+        errors = []
+
+        def check_key(n):
+            try:
+                for _ in range(100):
+                    rl.check(f"thread-{n}")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=check_key, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(errors) == 0, f"Thread safety errors: {errors}"


### PR DESCRIPTION
## Summary

Add per-API-key rate limiting and permission-based endpoint access control for v0.7.0.

## Changes

- **rate_limiter.py**: Sliding window rate limiter with per-key overrides (0=unlimited)
- **Permission decorator**: `@require_permission("read"|"write"|"admin")` on all endpoints
- **Migration v15**: `rate_limit` column + auto-promote existing keys to admin
- **auth.py**: `validate_key_against_db` returns 5-tuple including rate_limit
- **server.py**: Syncs per-key rate_limit from DB before enforcing
- **Tests**: 219/219 pass (16 rate limit + 19 permissions + 184 existing)

## Files: 21 changed (+867, -43)
